### PR TITLE
Add functionality to Ready to Operate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 build/**
+input/**
+core
+docker/**

--- a/example_fusion_power_plant.xml
+++ b/example_fusion_power_plant.xml
@@ -1,0 +1,36 @@
+<simulation>
+  <control>
+    <duration>10</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+  </control>
+
+  <archetypes>
+    <spec><lib>tricycle</lib><name>FusionPowerPlant</name></spec>
+    <spec><lib>agents</lib><name>NullInst</name></spec>
+    <spec><lib>agents</lib><name>NullRegion</name></spec>
+  </archetypes>
+
+  <facility>
+    <name>OneFacility</name>
+    <config>
+      <FusionPowerPlant />
+    </config>
+  </facility>
+
+  <region>
+    <name>OneRegion</name>
+    <config> <NullRegion /> </config>
+    <institution>
+      <name>OneInst</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>OneFacility</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config> <NullInst /> </config>
+    </institution>
+  </region>
+
+</simulation>

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -68,6 +68,32 @@ class FusionPowerPlant : public cyclus::Facility  {
 
   //State Variables:
   #pragma cyclus var { \
+    "doc": "Nameplate fusion power of the reactor", \
+    "tooltip": "Nameplate fusion power", \
+    "units": "MW", \
+    "uitype": "range", \
+    "range": [0, 1e299], \
+    "uilabel": "Fusion Power" \
+  }
+  double fusion_power;
+
+  #pragma cyclus var { \
+    "doc": "Minimum tritium inventory to hold in reserve in excess of operational quantity in case of tritium recovery system failure", \
+    "tooltip": "Minimum tritium inventory to hold in reserve", \
+    "units": "kg", \
+    "uilabel": "Reserve Inventory" \
+  }
+  double reserve_inventory;  
+
+  #pragma cyclus var { \
+    "doc": "Equilibrium quantity of tritium which is sequestered in the system and no longer accessable", \
+    "tooltip": "sequestered tritium equilibrium quantity, should be startup-reserve inventory", \
+    "units": "kg", \
+    "uilabel": "Equilibrium Quantity of Sequestered Tritium" \
+  }
+  double sequestered_equilibrium; 
+
+  #pragma cyclus var { \
     "doc": "Fresh fuel commodity", \
     "tooltip": "Name of fuel commodity requested", \
     "uilabel": "Fuel input commodity" \
@@ -170,12 +196,14 @@ class FusionPowerPlant : public cyclus::Facility  {
   //Functions:
   void CycleBlanket();
   bool BlanketCycleTime();
-  bool CheckOperatingConditions();
+  bool ReadyToOperate();
   void SequesterTritium();
   void OperateReactor();
   void DecayInventories();
   void ExtractHelium();
   void MoveExcessTritiumToSellBuffer();
+  double SequesteredTritiumGap();
+  bool TritiumStorageClean();
 
 
  private:
@@ -202,6 +230,8 @@ class FusionPowerPlant : public cyclus::Facility  {
   double blanket_limit = 100000.0; 
   Material::Ptr blanket;
   double blanket_turnover;
+  double fuel_usage_mass;
+  static const double burn_rate; // kg/GW-y
 
 
   //NucIDs for Pyne


### PR DESCRIPTION
Changed the name of the CheckOperationalConditions function to "ReadyToOperate" and added functionality required to support the condition check.

SequesterTritiumGap() was added to calculate the difference between sequestered_equilibrium and sequestered_tritium mass.

TritiumStorageClean() was added to verify that the incoming tritium commodity was actually tritium as expected by the FusionPowerPlant.