### PR TITLE
Fixed Various Startup Issues

### DIFF
--- a/src/fusion_power_plant.cc
+++ b/src/fusion_power_plant.cc
@@ -199,14 +199,14 @@ bool FusionPowerPlant::TritiumStorageClean() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 bool FusionPowerPlant::ReadyToOperate() {
 
-  // determine required tritium storage inventory
-  double required_storage_inventory = fuel_usage_mass + SequesteredTritiumGap();
-
-  // ensure correct startup behavior
-  if (sequestered_tritium->quantity() < cyclus::eps_rsrc() && tritium_storage.quantity() < startup_inventory) {
-    return false;
+  // Determine tritium inventory required to operate
+  if (sequestered_tritium->quantity() < cyclus::eps_rsrc()) {
+    double required_storage_inventory = reserve_inventory + SequesteredTritiumGap();
+  } else {
+    double required_storage_inventory = fuel_usage_mass + SequesteredTritiumGap();
   }
-  // check basic tritium storage quantity requirement
+
+  // check  tritium storage quantity requirement
   if (tritium_storage.quantity() < required_storage_inventory || !TritiumStorageClean()) {
     return false;
   }

--- a/src/fusion_power_plant.cc
+++ b/src/fusion_power_plant.cc
@@ -38,8 +38,7 @@ void FusionPowerPlant::EnterNotify() {
 
   fuel_usage_mass = (burn_rate * (fusion_power / MW_to_GW) / 
     (kDefaultTimeStepDur * 12) * context()->dt());
-  blanket_turnover = blanket_size * blanket_turnover_fraction;
-  startup_inventory = reserve_inventory + sequestered_equilibrium; 
+  blanket_turnover = blanket_size * blanket_turnover_fraction; 
   
   //Create the blanket material for use in the core, no idea if this works...
   blanket = Material::Create(this, 0.0, 
@@ -48,8 +47,8 @@ void FusionPowerPlant::EnterNotify() {
   fuel_startup_policy
     .Init(this, &tritium_storage, std::string("Tritium Storage"),
           &fuel_tracker, std::string("ss"),
-          startup_inventory,
-          startup_inventory)
+          reserve_inventory + sequestered_equilibrium,
+          reserve_inventory + sequestered_equilibrium)
     .Set(fuel_incommod, tritium_comp)
     .Start();
 

--- a/src/fusion_power_plant.cc
+++ b/src/fusion_power_plant.cc
@@ -198,12 +198,13 @@ bool FusionPowerPlant::TritiumStorageClean() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 bool FusionPowerPlant::ReadyToOperate() {
-
+  
   // Determine tritium inventory required to operate
+  double required_storage_inventory = SequesteredTritiumGap();
   if (sequestered_tritium->quantity() < cyclus::eps_rsrc()) {
-    double required_storage_inventory = reserve_inventory + SequesteredTritiumGap();
+    required_storage_inventory += reserve_inventory;
   } else {
-    double required_storage_inventory = fuel_usage_mass + SequesteredTritiumGap();
+    required_storage_inventory += fuel_usage_mass;
   }
 
   // check  tritium storage quantity requirement

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -259,6 +259,9 @@ class FusionPowerPlant : public cyclus::Facility  {
   double blanket_turnover;
   double fuel_usage_mass;
   static const double burn_rate; // kg/GW-y
+  double startup_inventory;
+  double tritium_yearly_decay_fraction = 0.055;
+  double trituim_overbuy_multiplier;
 
 
   //NucIDs for Pyne

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -258,9 +258,7 @@ class FusionPowerPlant : public cyclus::Facility  {
   Material::Ptr blanket;
   double blanket_turnover;
   double fuel_usage_mass;
-  static const double burn_rate; // kg/GW-y
   double startup_inventory;
-  static const double tritium_yearly_decay_fraction;
   double trituim_overbuy_multiplier;
 
 
@@ -274,6 +272,10 @@ class FusionPowerPlant : public cyclus::Facility  {
   //Materials:
   cyclus::Material::Ptr sequestered_tritium = cyclus::Material::CreateUntracked(0.0, tritium_comp);
   cyclus::Material::Ptr incore_fuel = cyclus::Material::CreateUntracked(0.0, tritium_comp);
+
+  // Constants
+  static const double burn_rate; // kg/GW-y
+  static const double tritium_yearly_decay_fraction;
 
   // And away we go!
 };

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -260,7 +260,7 @@ class FusionPowerPlant : public cyclus::Facility  {
   double fuel_usage_mass;
   static const double burn_rate; // kg/GW-y
   double startup_inventory;
-  double tritium_yearly_decay_fraction = 0.055;
+  static const double tritium_yearly_decay_fraction;
   double trituim_overbuy_multiplier;
 
 

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -258,7 +258,6 @@ class FusionPowerPlant : public cyclus::Facility  {
   Material::Ptr blanket;
   double blanket_turnover;
   double fuel_usage_mass;
-  double startup_inventory;
 
 
   //NucIDs for Pyne

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -259,7 +259,6 @@ class FusionPowerPlant : public cyclus::Facility  {
   double blanket_turnover;
   double fuel_usage_mass;
   double startup_inventory;
-  double trituim_overbuy_multiplier;
 
 
   //NucIDs for Pyne
@@ -275,7 +274,6 @@ class FusionPowerPlant : public cyclus::Facility  {
 
   // Constants
   static const double burn_rate; // kg/GW-y
-  static const double tritium_yearly_decay_fraction;
 
   // And away we go!
 };


### PR DESCRIPTION
This PR closes #24 

As described in the issue, FPPs could behave incorrectly at startup, either starting before they were supposed to (lack of a check for startup-inventory being reached) or would never startup at all in tritium-limited sims.