### PR TITLE
Fixed tritium_storage never decaying

### DIFF
--- a/src/fusion_power_plant.cc
+++ b/src/fusion_power_plant.cc
@@ -103,6 +103,9 @@ void FusionPowerPlant::EnterNotify() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::Tick() {
 
+  DecayInventories();
+  ExtractHelium();
+
   if (ReadyToOperate()) {
     fuel_startup_policy.Stop();
     fuel_refill_policy.Start();
@@ -114,9 +117,6 @@ void FusionPowerPlant::Tick() {
     // Some way of leaving a record of what is going wrong is helpful info I think
     // Use the cyclus logger
   }
-  
-  DecayInventories();
-  ExtractHelium();
   
   double excess_tritium = std::max(tritium_storage.quantity() - 
                                   (reserve_inventory + SequesteredTritiumGap())
@@ -188,6 +188,7 @@ bool FusionPowerPlant::ReadyToOperate() {
   double required_storage_inventory = SequesteredTritiumGap();
   if (sequestered_tritium->quantity() < cyclus::eps_rsrc()) {
     required_storage_inventory += reserve_inventory;
+    required_storage_inventory *= tritium_startup_fraction;
   } else {
     required_storage_inventory += fuel_usage_mass;
   }
@@ -209,10 +210,6 @@ void FusionPowerPlant::LoadCore() {
   if (SequesteredTritiumGap() > cyclus::eps_rsrc()) { 
     sequestered_tritium->Absorb(tritium_storage.Pop(SequesteredTritiumGap()));
   }
-
-  // Force decay of storage_inventory to avoid it resetting dt to 0
-  tritium_storage.Decay();
-  ExtractHelium();
 
   CycleBlanket();
   incore_fuel->Absorb(tritium_storage.Pop(fuel_usage_mass));

--- a/src/fusion_power_plant.cc
+++ b/src/fusion_power_plant.cc
@@ -102,7 +102,6 @@ void FusionPowerPlant::EnterNotify() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::Tick() {
-  
 
   if (ReadyToOperate()) {
     fuel_startup_policy.Stop();
@@ -206,19 +205,17 @@ bool FusionPowerPlant::ReadyToOperate() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::LoadCore() {
   
+  // Squash runs into issues when you give it zero, so we need to check frist
+  if (SequesteredTritiumGap() > cyclus::eps_rsrc()) { 
+    sequestered_tritium->Absorb(tritium_storage.Pop(SequesteredTritiumGap()));
+  }
+
   // Force decay of storage_inventory to avoid it resetting dt to 0
   tritium_storage.Decay();
   ExtractHelium();
 
   CycleBlanket();
-
-  // Squash runs into issues when you give it zero, so we need to check frist
-  if (SequesteredTritiumGap() > cyclus::eps_rsrc()) { 
-    sequestered_tritium->Absorb(tritium_storage.Pop(SequesteredTritiumGap()));
-  }
   incore_fuel->Absorb(tritium_storage.Pop(fuel_usage_mass));
-
-  
 
 }
 

--- a/src/fusion_power_plant.cc
+++ b/src/fusion_power_plant.cc
@@ -103,6 +103,7 @@ void FusionPowerPlant::EnterNotify() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::Tick() {
   
+
   if (ReadyToOperate()) {
     fuel_startup_policy.Stop();
     fuel_refill_policy.Start();
@@ -205,6 +206,10 @@ bool FusionPowerPlant::ReadyToOperate() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::LoadCore() {
   
+  // Force decay of storage_inventory to avoid it resetting dt to 0
+  tritium_storage.Decay();
+  ExtractHelium();
+
   CycleBlanket();
 
   // Squash runs into issues when you give it zero, so we need to check frist
@@ -212,6 +217,9 @@ void FusionPowerPlant::LoadCore() {
     sequestered_tritium->Absorb(tritium_storage.Pop(SequesteredTritiumGap()));
   }
   incore_fuel->Absorb(tritium_storage.Pop(fuel_usage_mass));
+
+  
+
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -110,7 +110,7 @@ class FusionPowerPlant : public cyclus::Facility  {
     "default": 0.9, \
     "doc": "Fraction of desired startup tritium inventory required. ", \
     "tooltip": "Fraction of reserve required for startup", \
-    "units": "Dimensionless", \
+    "units": "dimensionless", \
     "range": [0, 1], \
     "uilabel": "Tritium Startup Fraction" \
   }

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -109,7 +109,7 @@ class FusionPowerPlant : public cyclus::Facility  {
   #pragma cyclus var { \
     "default": 0.9, \
     "doc": "Fraction of desired startup tritium inventory required. ", \
-    "tooltip": "Gives flexibility accounting for decay", \
+    "tooltip": "Fraction of reserve required for startup", \
     "units": "Dimensionless", \
     "range": [0, 1], \
     "uilabel": "Tritium Startup Fraction" \

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -107,6 +107,16 @@ class FusionPowerPlant : public cyclus::Facility  {
   double sequestered_equilibrium; 
 
   #pragma cyclus var { \
+    "default": 0.9, \
+    "doc": "Fraction of desired startup tritium inventory required. ", \
+    "tooltip": "Gives flexibility accounting for decay", \
+    "units": "Dimensionless", \
+    "range": [0, 1], \
+    "uilabel": "Tritium Startup Fraction" \
+  }
+  double tritium_startup_fraction; 
+
+  #pragma cyclus var { \
     "doc": "Fresh fuel commodity", \
     "tooltip": "Name of fuel commodity requested", \
     "uilabel": "Fuel input commodity" \

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -108,7 +108,7 @@ class FusionPowerPlant : public cyclus::Facility  {
 
   #pragma cyclus var { \
     "default": 0.9, \
-    "doc": "Fraction of desired startup tritium inventory required. ", \
+    "doc": "Fraction of desired startup ( = reserve + sequestered) tritium inventory required for initial startup. ", \
     "tooltip": "Fraction of reserve required for startup", \
     "units": "dimensionless", \
     "range": [0, 1], \

--- a/src/fusion_power_plant_tests.cc
+++ b/src/fusion_power_plant_tests.cc
@@ -96,13 +96,13 @@ TEST_F(FusionPowerPlantTest, Print) {
 }
 
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, Tock) {
   EXPECT_NO_THROW(facility->Tock());
   // Test FusionPowerPlant specific behaviors of the Tock function here
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, BlanketCycle) {
   // Test that the agent correctly removes and replaces a portion of the
   // blanket every blanket turnover period. The default period is 1 timestep
@@ -154,7 +154,7 @@ TEST_F(FusionPowerPlantTest, BlanketOverCycle) {
   EXPECT_NO_THROW(sim.Run());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, WrongFuelStartup) {
   // Test that the agent can identify that it has not recieved the correct fuel
   // to startup, and will appropriately not run.
@@ -181,7 +181,7 @@ TEST_F(FusionPowerPlantTest, WrongFuelStartup) {
   EXPECT_EQ(0, seq_trit);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, DecayInventoryExtractHelium) {
   // Test behaviors of the DecayInventory and ExtractHelium function here
   EXPECT_NO_THROW(facility->DecayInventories());
@@ -216,7 +216,7 @@ TEST_F(FusionPowerPlantTest, DecayInventoryExtractHelium) {
   EXPECT_NEAR(expected_decay, he3, 1e-6);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, Li7EdgeCases) {
   // Test that FPP does the same thing regardless of Li-7 Contribution
 
@@ -250,7 +250,7 @@ TEST_F(FusionPowerPlantTest, Li7EdgeCases) {
   EXPECT_NEAR(excess_1, excess_2, 1e-3);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, OperateReactorSustainingTBR) {
   // Test behaviors of the OperateReactor function here
 
@@ -270,7 +270,7 @@ TEST_F(FusionPowerPlantTest, OperateReactorSustainingTBR) {
   EXPECT_LT(0, excess_quantity);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, EnterNotifyInitialFillDefault) {
   // Test default fill behavior of EnterNotify. Specifically look that
   // tritium is transacted in the appropriate amounts.
@@ -298,7 +298,7 @@ TEST_F(FusionPowerPlantTest, EnterNotifyInitialFillDefault) {
   EXPECT_EQ(8.121, quantity);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, EnterNotifyScheduleFill) {
   // Test schedule fill behavior of EnterNotify.
 
@@ -341,7 +341,7 @@ TEST_F(FusionPowerPlantTest, EnterNotifyScheduleFill) {
   EXPECT_EQ(0.1, quantity_2);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, EnterNotifyInvalidFill) {
   // Test catch for invalid fill behavior keyword in EnterNotify.
 
@@ -357,8 +357,8 @@ TEST_F(FusionPowerPlantTest, EnterNotifyInvalidFill) {
 
   EXPECT_THROW(int id = sim.Run(), cyclus::KeyError);
 }
-// Unfinished
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
   // Test sell policy behavior of enter notify.
 
@@ -388,7 +388,7 @@ TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
 
 
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Do Not Touch! Below section required for connection with Cyclus
 cyclus::Agent* FusionPowerPlantConstructor(cyclus::Context* ctx) {
   return new FusionPowerPlant(ctx);

--- a/src/fusion_power_plant_tests.cc
+++ b/src/fusion_power_plant_tests.cc
@@ -210,7 +210,7 @@ TEST_F(FusionPowerPlantTest, DecayInventoryExtractHelium) {
   double lambda = 2.57208504984001213e-09; 
   double t = 2629846;
 
-  double expected_decay = reserve - reserve * std::pow(2, -lambda * t);
+  double expected_decay = init_quant - init_quant * std::pow(2, -lambda * t);
 
   EXPECT_NEAR(expected_decay, he3, 1e-6);
 }

--- a/src/fusion_power_plant_tests.cc
+++ b/src/fusion_power_plant_tests.cc
@@ -210,8 +210,7 @@ TEST_F(FusionPowerPlantTest, DecayInventoryExtractHelium) {
   double lambda = 2.57208504984001213e-09; 
   double t = 2629846;
 
-  double expected_decay = (init_quant - sequestered) 
-              - (init_quant - sequestered) * std::pow(2, -lambda * t);
+  double expected_decay = reserve - reserve * std::pow(2, -lambda * t);
 
   EXPECT_NEAR(expected_decay, he3, 1e-6);
 }


### PR DESCRIPTION
Closes #27 

<img width="587" alt="Screenshot 2025-01-30 at 10 09 55 AM" src="https://github.com/user-attachments/assets/4936642c-ae6c-425a-800a-82bc88f0d8be" />



Some work was done to determine why Tricycle's internal inventories weren't matching what we expected them to be theoretically, and through that work it was discovered that the `tritium_storage` ResBuf was never decaying. Two lines of code were added to the very beginning of the `LoadCore()` function to fix this.

```
tritium_storage.Decay();
ExtractHelium();
```

This forces a decay of tritium_storage right before new tritium is bred, which avoids it always having its dt = 0 from always being "fresh" after the burn-breed cycle (this is what was causing the issue). It should be logic safe from the perspective of decay, since double decaying in the same time step does nothing (Decay() sets prev_decay_time to the current time making dt = 0 after decay). After this change, we have the following:

![Inventory Behavior Comparison](https://github.com/user-attachments/assets/386adf5e-4136-4281-a3b2-b37c0a6c6dcb)


Note:  this may cause a logic issue with how we check whether there's enough tritium in the system to operate in the edge case where a user sets their `reserve_inventory` too low (too close to the amount of tritium that actually gets burned in the system). I haven't thought much about how to deal with this, but figured it would be best to get this PR in and then maybe make a different issue later to fix that if we decide it's a problem. If the issue occurs it should crash the sim (`LoadCore()` will try to extract more tritium that exists from `tritium_storage` and I think that throws an error), instead of quietly giving incorrect results.