### PR TITLE
Code Formatting PR

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+---
+Language:        Cpp
+BasedOnStyle:  Google
+# only allow single line functions if they are inlined in class def'n
+AllowShortFunctionsOnASingleLine: Inline
+# do not force new line after template declarations
+AlwaysBreakTemplateDeclarations: false
+# Automatically detect whether a given fuction's arguments are one-per-line
+ExperimentalAutoDetectBinPacking: true
+# Use C++11 standard
+Standard:        Cpp11

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,2 @@
+# Ignore header files:
+*.h

--- a/src/fusion_power_plant.cc
+++ b/src/fusion_power_plant.cc
@@ -1,13 +1,13 @@
 #include "fusion_power_plant.h"
 
-using cyclus::Material;
-using cyclus::Composition;
 using cyclus::CompMap;
-using cyclus::IntDistribution;
+using cyclus::Composition;
 using cyclus::DoubleDistribution;
-using cyclus::FixedIntDist;
 using cyclus::FixedDoubleDist;
+using cyclus::FixedIntDist;
+using cyclus::IntDistribution;
 using cyclus::KeyError;
+using cyclus::Material;
 using cyclus::toolkit::ResBuf;
 
 namespace tricycle {
@@ -16,7 +16,8 @@ const double FusionPowerPlant::burn_rate = 55.8;
 const double MW_to_GW = 1000;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-FusionPowerPlant::FusionPowerPlant(cyclus::Context* ctx) : cyclus::Facility(ctx) {
+FusionPowerPlant::FusionPowerPlant(cyclus::Context* ctx)
+    : cyclus::Facility(ctx) {
   fuel_tracker.Init({&tritium_storage}, fuel_limit);
   blanket_tracker.Init({&blanket_feed}, blanket_limit);
 
@@ -36,42 +37,38 @@ std::string FusionPowerPlant::str() {
 void FusionPowerPlant::EnterNotify() {
   cyclus::Facility::EnterNotify();
 
-  fuel_usage_mass = (burn_rate * (fusion_power / MW_to_GW) / 
-    (kDefaultTimeStepDur * 12) * context()->dt());
-  blanket_turnover = blanket_size * blanket_turnover_fraction; 
-  
-  //Create the blanket material for use in the core, no idea if this works...
-  blanket = Material::Create(this, 0.0, 
-    context()->GetRecipe(blanket_inrecipe));
+  fuel_usage_mass = (burn_rate * (fusion_power / MW_to_GW) /
+                     (kDefaultTimeStepDur * 12) * context()->dt());
+  blanket_turnover = blanket_size * blanket_turnover_fraction;
+
+  // Create the blanket material for use in the core, no idea if this works...
+  blanket = Material::Create(this, 0.0, context()->GetRecipe(blanket_inrecipe));
 
   fuel_startup_policy
-    .Init(this, &tritium_storage, std::string("Tritium Storage"),
-          &fuel_tracker, std::string("ss"),
-          reserve_inventory + sequestered_equilibrium,
-          reserve_inventory + sequestered_equilibrium)
-    .Set(fuel_incommod, tritium_comp)
-    .Start();
+      .Init(this, &tritium_storage, std::string("Tritium Storage"),
+            &fuel_tracker, std::string("ss"),
+            reserve_inventory + sequestered_equilibrium,
+            reserve_inventory + sequestered_equilibrium)
+      .Set(fuel_incommod, tritium_comp)
+      .Start();
 
   blanket_fill_policy
-      .Init(this, &blanket_feed, std::string("Blanket Startup"), &blanket_tracker,
-            std::string("ss"), blanket_size, blanket_size)
+      .Init(this, &blanket_feed, std::string("Blanket Startup"),
+            &blanket_tracker, std::string("ss"), blanket_size, blanket_size)
       .Set(blanket_incommod)
       .Start();
 
   // Tritium Buy Policy Selection:
   if (refuel_mode == "schedule") {
-    IntDistribution::Ptr active_dist = 
-      FixedIntDist::Ptr(new FixedIntDist(1));
-    IntDistribution::Ptr dormant_dist = 
-      FixedIntDist::Ptr(new FixedIntDist(buy_frequency - 1));
-    DoubleDistribution::Ptr size_dist = 
-      FixedDoubleDist::Ptr(new FixedDoubleDist(1));
+    IntDistribution::Ptr active_dist = FixedIntDist::Ptr(new FixedIntDist(1));
+    IntDistribution::Ptr dormant_dist =
+        FixedIntDist::Ptr(new FixedIntDist(buy_frequency - 1));
+    DoubleDistribution::Ptr size_dist =
+        FixedDoubleDist::Ptr(new FixedDoubleDist(1));
 
     fuel_refill_policy
-        .Init(this, &tritium_storage, std::string("Input"), 
-              &fuel_tracker,
-              buy_quantity, 
-              active_dist, dormant_dist, size_dist)
+        .Init(this, &tritium_storage, std::string("Input"), &fuel_tracker,
+              buy_quantity, active_dist, dormant_dist, size_dist)
         .Set(fuel_incommod, tritium_comp);
 
   } else if (refuel_mode == "fill") {
@@ -81,12 +78,11 @@ void FusionPowerPlant::EnterNotify() {
         .Set(fuel_incommod, tritium_comp);
 
   } else {
-    throw KeyError("Refuel mode " + refuel_mode + 
-                    " not recognized! Try 'schedule' or 'fill'.");
+    throw KeyError("Refuel mode " + refuel_mode +
+                   " not recognized! Try 'schedule' or 'fill'.");
   }
 
-  tritium_sell_policy
-      .Init(this, &tritium_excess, std::string("Excess Tritium"))
+  tritium_sell_policy.Init(this, &tritium_excess, std::string("Excess Tritium"))
       .Set(fuel_incommod)
       .Start();
 
@@ -102,26 +98,26 @@ void FusionPowerPlant::EnterNotify() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::Tick() {
-  
   if (ReadyToOperate()) {
     fuel_startup_policy.Stop();
     fuel_refill_policy.Start();
-    
+
     LoadCore();
     OperateReactor();
-    
+
   } else {
-    // Some way of leaving a record of what is going wrong is helpful info I think
-    // Use the cyclus logger
+    // Some way of leaving a record of what is going wrong is helpful info I
+    // think Use the cyclus logger
   }
-  
+
   DecayInventories();
   ExtractHelium();
-  
-  double excess_tritium = std::max(tritium_storage.quantity() - 
-                                  (reserve_inventory + SequesteredTritiumGap())
-                                  , 0.0);
-  
+
+  double excess_tritium =
+      std::max(tritium_storage.quantity() -
+                   (reserve_inventory + SequesteredTritiumGap()),
+               0.0);
+
   // Otherwise the ResBuf encounters an error when it tries to squash
   if (excess_tritium > cyclus::eps_rsrc()) {
     tritium_excess.Push(tritium_storage.Pop(excess_tritium));
@@ -135,19 +131,18 @@ void FusionPowerPlant::Tick() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::Tock() {
-  
   // ExplicitInventories wasn't working. If possible, may be best to use that
   // down the road.
-  RecordInventories(tritium_storage.quantity(), tritium_excess.quantity(), 
+  RecordInventories(tritium_storage.quantity(), tritium_excess.quantity(),
                     sequestered_tritium->quantity(), blanket_feed.quantity(),
                     blanket_waste.quantity(), helium_excess.quantity());
 }
 
-void FusionPowerPlant::RecordInventories(double tritium_storage, 
-                                         double tritium_excess, 
-                                         double sequestered_tritium, 
-                                         double blanket_feed, 
-                                         double blanket_waste, 
+void FusionPowerPlant::RecordInventories(double tritium_storage,
+                                         double tritium_excess,
+                                         double sequestered_tritium,
+                                         double blanket_feed,
+                                         double blanket_waste,
                                          double helium_excess) {
   context()
       ->NewDatum("FPPInventories")
@@ -172,18 +167,13 @@ double FusionPowerPlant::SequesteredTritiumGap() {
   return std::max(sequestered_equilibrium - current_sequestered_tritium, 0.0);
 }
 
-
 bool FusionPowerPlant::TritiumStorageClean() {
-
   cyclus::toolkit::MatQuery mq(tritium_storage.Peek());
   return cyclus::AlmostEq(mq.mass(tritium_id), tritium_storage.quantity());
-
 }
-
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 bool FusionPowerPlant::ReadyToOperate() {
-  
   // Determine tritium inventory required to operate
   double required_storage_inventory = SequesteredTritiumGap();
   if (sequestered_tritium->quantity() < cyclus::eps_rsrc()) {
@@ -193,7 +183,8 @@ bool FusionPowerPlant::ReadyToOperate() {
   }
 
   // check  tritium storage quantity requirement
-  if (tritium_storage.quantity() < required_storage_inventory || !TritiumStorageClean()) {
+  if (tritium_storage.quantity() < required_storage_inventory ||
+      !TritiumStorageClean()) {
     return false;
   }
   if (BlanketCycleTime() && blanket_feed.quantity() < blanket_turnover) {
@@ -204,11 +195,10 @@ bool FusionPowerPlant::ReadyToOperate() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::LoadCore() {
-  
   CycleBlanket();
 
   // Squash runs into issues when you give it zero, so we need to check frist
-  if (SequesteredTritiumGap() > cyclus::eps_rsrc()) { 
+  if (SequesteredTritiumGap() > cyclus::eps_rsrc()) {
     sequestered_tritium->Absorb(tritium_storage.Pop(SequesteredTritiumGap()));
   }
   incore_fuel->Absorb(tritium_storage.Pop(fuel_usage_mass));
@@ -219,7 +209,7 @@ void FusionPowerPlant::BreedTritium(double T_burned) {
   int Li6_id = pyne::nucname::id("Li-6");
   int Li7_id = pyne::nucname::id("Li-7");
   int He4_id = pyne::nucname::id("He-4");
-  
+
   double Li6_molar_mass = pyne::atomic_mass(Li6_id);
   double Li7_molar_mass = pyne::atomic_mass(Li7_id);
   double T_molar_mass = pyne::atomic_mass(tritium_id);
@@ -227,16 +217,20 @@ void FusionPowerPlant::BreedTritium(double T_burned) {
 
   Composition::Ptr Li6 = Composition::CreateFromAtom(CompMap({{Li6_id, 1.0}}));
   Composition::Ptr Li7 = Composition::CreateFromAtom(CompMap({{Li7_id, 1.0}}));
-  Composition::Ptr Tritium = Composition::CreateFromAtom(CompMap({{tritium_id, 1.0}}));
+  Composition::Ptr Tritium =
+      Composition::CreateFromAtom(CompMap({{tritium_id, 1.0}}));
   Composition::Ptr He4 = Composition::CreateFromAtom(CompMap({{He4_id, 1.0}}));
 
   // Breed tritium
   Material::Ptr T_created = Material::Create(this, T_burned * TBR, Tritium);
   double T_created_atoms = T_created->quantity() * T_molar_mass;
-  Material::Ptr Li7_burned = Material::CreateUntracked(T_created_atoms * Li7_contribution/Li7_molar_mass, Li7);
-  Material::Ptr Li6_burned = Material::CreateUntracked(T_created_atoms * (1-Li7_contribution) / Li6_molar_mass, Li6);
-  Material::Ptr He4_generated = Material::CreateUntracked(T_created_atoms/He4_molar_mass, He4);
-  
+  Material::Ptr Li7_burned = Material::CreateUntracked(
+      T_created_atoms * Li7_contribution / Li7_molar_mass, Li7);
+  Material::Ptr Li6_burned = Material::CreateUntracked(
+      T_created_atoms * (1 - Li7_contribution) / Li6_molar_mass, Li6);
+  Material::Ptr He4_generated =
+      Material::CreateUntracked(T_created_atoms / He4_molar_mass, He4);
+
   Material::Ptr consumed_Li = blanket->ExtractComp(Li7_burned->quantity(), Li7);
   consumed_Li->Absorb(blanket->ExtractComp(Li6_burned->quantity(), Li6));
   blanket->Absorb(He4_generated);
@@ -245,32 +239,29 @@ void FusionPowerPlant::BreedTritium(double T_burned) {
 }
 
 void FusionPowerPlant::OperateReactor() {
-
   Material::Ptr consumed_fuel = incore_fuel->ExtractQty(fuel_usage_mass);
   BreedTritium(fuel_usage_mass);
-
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::DecayInventories() {
   tritium_storage.Decay();
   tritium_excess.Decay();
   sequestered_tritium->Decay(context()->time());
-  
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::ExtractHelium() {
-
   int He3_id = pyne::nucname::id("He-3");
   Composition::Ptr He3 = Composition::CreateFromAtom(CompMap({{He3_id, 1.0}}));
 
-  std::vector<ResBuf<Material>*> tritium_buffers = {&tritium_storage, &tritium_excess};
+  std::vector<ResBuf<Material>*> tritium_buffers = {&tritium_storage,
+                                                    &tritium_excess};
 
   for (auto* inventory : tritium_buffers) {
     if (!inventory->empty()) {
       Material::Ptr mat = inventory->Pop();
       cyclus::toolkit::MatQuery mq(mat);
-      
+
       Material::Ptr helium = mat->ExtractComp(mq.mass(He3_id), He3);
 
       helium_excess.Push(helium);
@@ -281,20 +272,17 @@ void FusionPowerPlant::ExtractHelium() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::CycleBlanket() {
-  
   if (blanket->quantity() < cyclus::eps_rsrc()) {
     blanket->Absorb(blanket_feed.Pop(blanket_size));
   } else if (BlanketCycleTime()) {
-
     blanket_waste.Push(blanket->ExtractQty(blanket_turnover));
     blanket->Absorb(blanket_feed.Pop(blanket_turnover));
-
   }
 }
 
-bool FusionPowerPlant::BlanketCycleTime(){
+bool FusionPowerPlant::BlanketCycleTime() {
   return ((context()->time() > 0) &&
-          (context()->time() % blanket_turnover_frequency == 0) );
+          (context()->time() % blanket_turnover_frequency == 0));
 }
 
 // WARNING! Do not change the following this function!!! This enables your
@@ -305,4 +293,3 @@ extern "C" cyclus::Agent* ConstructFusionPowerPlant(cyclus::Context* ctx) {
 }
 
 }  // namespace tricycle
-

--- a/src/fusion_power_plant_tests.cc
+++ b/src/fusion_power_plant_tests.cc
@@ -1,20 +1,19 @@
 #include <gtest/gtest.h>
 
-#include "fusion_power_plant.h"
+#include <cmath>
 
 #include "agent_tests.h"
 #include "context.h"
 #include "facility_tests.h"
+#include "fusion_power_plant.h"
 #include "pyhooks.h"
-#include <cmath>
 
-using tricycle::FusionPowerPlant;
 using cyclus::CompMap;
 using cyclus::Cond;
 using cyclus::Material;
 using cyclus::QueryResult;
 using cyclus::toolkit::MatQuery;
-
+using tricycle::FusionPowerPlant;
 
 Composition::Ptr tritium() {
   cyclus::CompMap m;
@@ -37,18 +36,18 @@ Composition::Ptr enriched_lithium() {
 };
 
 std::string common_config =
-" <fusion_power>300</fusion_power>"
-" <reserve_inventory>6.0</reserve_inventory>"
-" <sequestered_equilibrium>2.121</sequestered_equilibrium>"
-" <blanket_incommod>Enriched_Lithium</blanket_incommod>"
-" <blanket_outcommod>Depleted_Lithium</blanket_outcommod>"
-" <blanket_inrecipe>enriched_lithium</blanket_inrecipe>"
-" <blanket_size>1000</blanket_size>"
-" <he3_outcommod>Helium_3</he3_outcommod>";
-
+    " <fusion_power>300</fusion_power>"
+    " <reserve_inventory>6.0</reserve_inventory>"
+    " <sequestered_equilibrium>2.121</sequestered_equilibrium>"
+    " <blanket_incommod>Enriched_Lithium</blanket_incommod>"
+    " <blanket_outcommod>Depleted_Lithium</blanket_outcommod>"
+    " <blanket_inrecipe>enriched_lithium</blanket_inrecipe>"
+    " <blanket_size>1000</blanket_size>"
+    " <he3_outcommod>Helium_3</he3_outcommod>";
 
 cyclus::MockSim InitializeSim(std::string config, int simdur) {
-  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config,
+                      simdur);
 
   sim.AddRecipe("tritium", tritium());
   sim.AddRecipe("enriched_lithium", enriched_lithium());
@@ -95,7 +94,6 @@ TEST_F(FusionPowerPlantTest, Print) {
   // Test FusionPowerPlant specific aspects of the print method here
 }
 
-
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, Tock) {
   EXPECT_NO_THROW(facility->Tock());
@@ -108,7 +106,8 @@ TEST_F(FusionPowerPlantTest, BlanketCycle) {
   // blanket every blanket turnover period. The default period is 1 timestep
   // so it is left undefined here.
 
-  std::string config = common_config +
+  std::string config =
+      common_config +
       " <fusion_power>300</fusion_power>"
       " <TBR>1.00</TBR>"
       " <fuel_incommod>Tritium</fuel_incommod>"
@@ -128,18 +127,18 @@ TEST_F(FusionPowerPlantTest, BlanketCycle) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, BlanketOverCycle) {
-  // Test the catch for an overcycle of the blanket. The simulation 
+  // Test the catch for an overcycle of the blanket. The simulation
   // should not crash when this happens.
 
-  std::string config = common_config + 
+  std::string config =
+      common_config +
       "  <TBR>1.00</TBR>"
       " <fuel_incommod>Tritium</fuel_incommod>"
       " <blanket_turnover_fraction>0.03</blanket_turnover_fraction>";
 
   int simdur = 2;
-  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config, simdur);
-
-
+  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config,
+                      simdur);
 
   sim.AddRecipe("tritium", tritium());
   sim.AddRecipe("enriched_lithium", enriched_lithium());
@@ -150,7 +149,6 @@ TEST_F(FusionPowerPlantTest, BlanketOverCycle) {
       .recipe("enriched_lithium")
       .Finalize();
 
-
   EXPECT_NO_THROW(sim.Run());
 }
 
@@ -159,13 +157,15 @@ TEST_F(FusionPowerPlantTest, WrongFuelStartup) {
   // Test that the agent can identify that it has not recieved the correct fuel
   // to startup, and will appropriately not run.
 
-  std::string config = common_config +
+  std::string config =
+      common_config +
       "  <TBR>1.00</TBR>"
       " <fuel_incommod>Enriched_Lithium</fuel_incommod>"
       " <blanket_turnover_fraction>0.03</blanket_turnover_fraction>";
 
   int simdur = 3;
-  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config,
+                      simdur);
 
   sim.AddRecipe("tritium", tritium());
   sim.AddRecipe("enriched_lithium", enriched_lithium());
@@ -189,14 +189,13 @@ TEST_F(FusionPowerPlantTest, DecayInventoryExtractHelium) {
   // We use unintuitive values for reserve inventory and startup inventory here
   // because they were the values we were originally testing with, and we had
   // already done all the calculations.
-  std::string config = common_config + 
-      " <TBR>1.00</TBR> "
-      " <fuel_incommod>Tritium</fuel_incommod>";
-
+  std::string config = common_config +
+                       " <TBR>1.00</TBR> "
+                       " <fuel_incommod>Tritium</fuel_incommod>";
 
   int simdur = 2;
   cyclus::MockSim sim = InitializeSim(config, simdur);
-  
+
   int id = sim.Run();
 
   QueryResult qr = TimeInventoryQuery(sim, "1");
@@ -207,11 +206,11 @@ TEST_F(FusionPowerPlantTest, DecayInventoryExtractHelium) {
 
   double init_quant = reserve + sequestered;
   // Lambda in base 2, not base e (see Decay.cc for more info)
-  double lambda = 2.57208504984001213e-09; 
+  double lambda = 2.57208504984001213e-09;
   double t = 2629846;
 
-  double expected_decay = (init_quant - sequestered) 
-              - (init_quant - sequestered) * std::pow(2, -lambda * t);
+  double expected_decay = (init_quant - sequestered) -
+                          (init_quant - sequestered) * std::pow(2, -lambda * t);
 
   EXPECT_NEAR(expected_decay, he3, 1e-6);
 }
@@ -221,21 +220,20 @@ TEST_F(FusionPowerPlantTest, Li7EdgeCases) {
   // Test that FPP does the same thing regardless of Li-7 Contribution
 
   std::string config_1 = common_config +
-      " <TBR>1.08</TBR> "
-      " <fuel_incommod>Tritium</fuel_incommod>"
-      " <he3_outcommod>Helium_3</he3_outcommod>"
-      " <Li7_contribution>0.00</Li7_contribution>";
+                         " <TBR>1.08</TBR> "
+                         " <fuel_incommod>Tritium</fuel_incommod>"
+                         " <he3_outcommod>Helium_3</he3_outcommod>"
+                         " <Li7_contribution>0.00</Li7_contribution>";
 
   std::string config_2 = common_config +
-      " <TBR>1.08</TBR> "
-      " <fuel_incommod>Tritium</fuel_incommod>"
-      " <Li7_contribution>1.00</Li7_contribution>";
+                         " <TBR>1.08</TBR> "
+                         " <fuel_incommod>Tritium</fuel_incommod>"
+                         " <Li7_contribution>1.00</Li7_contribution>";
 
   int simdur = 2;
   cyclus::MockSim sim_1 = InitializeSim(config_1, simdur);
 
   int id_1 = sim_1.Run();
-
 
   cyclus::MockSim sim_2 = InitializeSim(config_2, simdur);
 
@@ -255,8 +253,8 @@ TEST_F(FusionPowerPlantTest, OperateReactorSustainingTBR) {
   // Test behaviors of the OperateReactor function here
 
   std::string config = common_config +
-      " <TBR>1.08</TBR> "
-      " <fuel_incommod>Tritium</fuel_incommod>";
+                       " <TBR>1.08</TBR> "
+                       " <fuel_incommod>Tritium</fuel_incommod>";
 
   int simdur = 10;
   cyclus::MockSim sim = InitializeSim(config, simdur);
@@ -276,8 +274,8 @@ TEST_F(FusionPowerPlantTest, EnterNotifyInitialFillDefault) {
   // tritium is transacted in the appropriate amounts.
 
   std::string config = common_config +
-      " <TBR>1.00</TBR> "
-      " <fuel_incommod>Tritium</fuel_incommod>";
+                       " <TBR>1.00</TBR> "
+                       " <fuel_incommod>Tritium</fuel_incommod>";
 
   int simdur = 2;
   cyclus::MockSim sim = InitializeSim(config, simdur);
@@ -303,11 +301,11 @@ TEST_F(FusionPowerPlantTest, EnterNotifyScheduleFill) {
   // Test schedule fill behavior of EnterNotify.
 
   std::string config = common_config +
-      " <TBR>1.00</TBR> "
-      " <fuel_incommod>Tritium</fuel_incommod>"
-      " <buy_quantity>0.1</buy_quantity>"
-      " <buy_frequency>1</buy_frequency>"
-      " <refuel_mode>schedule</refuel_mode>";
+                       " <TBR>1.00</TBR> "
+                       " <fuel_incommod>Tritium</fuel_incommod>"
+                       " <buy_quantity>0.1</buy_quantity>"
+                       " <buy_frequency>1</buy_frequency>"
+                       " <refuel_mode>schedule</refuel_mode>";
 
   int simdur = 2;
   cyclus::MockSim sim = InitializeSim(config, simdur);
@@ -346,11 +344,11 @@ TEST_F(FusionPowerPlantTest, EnterNotifyInvalidFill) {
   // Test catch for invalid fill behavior keyword in EnterNotify.
 
   std::string config = common_config +
-      " <TBR>1.00</TBR> "
-      " <fuel_incommod>Tritium</fuel_incommod>"
-      " <buy_quantity>0.1</buy_quantity>"
-      " <buy_frequency>1</buy_frequency>"
-      " <refuel_mode>kjnsfdhn</refuel_mode>";
+                       " <TBR>1.00</TBR> "
+                       " <fuel_incommod>Tritium</fuel_incommod>"
+                       " <buy_quantity>0.1</buy_quantity>"
+                       " <buy_frequency>1</buy_frequency>"
+                       " <refuel_mode>kjnsfdhn</refuel_mode>";
 
   int simdur = 2;
   cyclus::MockSim sim = InitializeSim(config, simdur);
@@ -363,11 +361,12 @@ TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
   // Test sell policy behavior of enter notify.
 
   std::string config = common_config +
-      " <TBR>1.30</TBR> "
-      " <fuel_incommod>Tritium</fuel_incommod>";
+                       " <TBR>1.30</TBR> "
+                       " <fuel_incommod>Tritium</fuel_incommod>";
 
   int simdur = 10;
-  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config, simdur);
+  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config,
+                      simdur);
 
   sim.AddRecipe("tritium", tritium());
   sim.AddRecipe("enriched_lithium", enriched_lithium());
@@ -385,8 +384,6 @@ TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
 
   EXPECT_EQ(simdur, qr_rows);
 }
-
-
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Do Not Touch! Below section required for connection with Cyclus


### PR DESCRIPTION
The code was, previously, not formatted with clang-format. This PR fixes that. Ran unit tests and a sample problem to make sure nothing fundamentally broke.

Closes #29 

Note, it was not possible to format the .h file, since it would break the #pragma lines.
