### PR TITLE
Add Decay Storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/**
 input/**
 core
 docker/**
+.vscode/**
+run_cyclus.sh

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 ### DO NOT DELETE THIS COMMENT: INSERT_ARCHETYPES_HERE ###
 USE_CYCLUS("tricycle" "fusion_power_plant")
 
+USE_CYCLUS("tricycle" "decay_storage")
+
 INSTALL_CYCLUS_MODULE("tricycle" "")
 
 # install header files

--- a/src/decay_storage.cc
+++ b/src/decay_storage.cc
@@ -6,9 +6,9 @@ namespace decaystorage {
 DecayStorage::DecayStorage(cyclus::Context* ctx) : cyclus::Facility(ctx) {
   fuel_tracker.Init({&input}, 100000000);
 
-  input = ResBuf<Material>(true);
-  tritium_storage = ResBuf<Material>(true);
-  helium_storage = ResBuf<Material>(true);
+  input = cyclus::toolkit::ResBuf<cyclus::Material>(true);
+  tritium_storage = cyclus::toolkit::ResBuf<cyclus::Material>(true);
+  helium_storage = cyclus::toolkit::ResBuf<cyclus::Material>(true);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/decay_storage.cc
+++ b/src/decay_storage.cc
@@ -29,15 +29,6 @@ void DecayStorage::RecordInventories(double tritium, double helium) {
       ->Record();
 }
 
-void DecayStorage::DecayInventory(
-    cyclus::toolkit::ResBuf<cyclus::Material>& inventory) {
-  if (!inventory.empty()) {
-    cyclus::Material::Ptr mat = inventory.Pop();
-    mat->Decay(context()->time());
-    inventory.Push(mat);
-  }
-}
-
 void DecayStorage::ExtractHelium(
     cyclus::toolkit::ResBuf<cyclus::Material>& inventory) {
   if (!inventory.empty()) {
@@ -51,34 +42,18 @@ void DecayStorage::ExtractHelium(
   }
 }
 
-void DecayStorage::CombineInventory(
-    cyclus::toolkit::ResBuf<cyclus::Material>& inventory) {
-  if (!inventory.empty()) {
-    cyclus::Material::Ptr base = inventory.Pop();
-    int count = inventory.count();
-    for (int i = 0; i < count; i++) {
-      cyclus::Material::Ptr m = inventory.Pop();
-      base->Absorb(m);
-    }
-
-    inventory.Push(base);
-  }
-}
-
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void DecayStorage::Tick() {
-  DecayInventory(tritium_storage);
+  tritium_storage.Decay(context()->time());
   ExtractHelium(tritium_storage);
   LOG(cyclus::LEV_INFO2, "Storage") << "Quantity to be offered: " << sell_policy.Limit() << " kg.";
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void DecayStorage::Tock() {
-  CombineInventory(input);
   if (!input.empty()){
     tritium_storage.Push(input.Pop());
   }
-  CombineInventory(tritium_storage);
   RecordInventories(tritium_storage.quantity(), helium_storage.quantity());
 }
 

--- a/src/decay_storage.cc
+++ b/src/decay_storage.cc
@@ -5,7 +5,7 @@ namespace decaystorage {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 DecayStorage::DecayStorage(cyclus::Context* ctx) : cyclus::Facility(ctx) {
   // Required by DRE policies
-  fuel_tracker.Init({&tritium_storage}, 100000000);
+  fuel_tracker.Init({&tritium_storage}, max_tritium_inventory);
 
   bool is_bulk = true;
 

--- a/src/decay_storage.cc
+++ b/src/decay_storage.cc
@@ -1,0 +1,92 @@
+#include "decay_storage.h"
+
+namespace decaystorage {
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+DecayStorage::DecayStorage(cyclus::Context* ctx) : cyclus::Facility(ctx) {
+  fuel_tracker.Init({&input}, 10000);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+std::string DecayStorage::str() {
+  return Facility::str();
+}
+
+void DecayStorage::EnterNotify() {
+  cyclus::Facility::EnterNotify(); // call base function first
+  buy_policy.Init(this, &input, std::string("input"), &fuel_tracker).Set(incommod).Start();
+  sell_policy.Init(this, &tritium_storage, std::string("output")).Set(outcommod).Start();
+}
+
+void DecayStorage::RecordInventories(double tritium, double helium) {
+  context()
+      ->NewDatum("StorageInventories")
+      ->AddVal("AgentId", id())
+      ->AddVal("Time", context()->time())
+      ->AddVal("TritiumStorage", tritium)
+      ->AddVal("HeliumStorage", helium)
+
+      ->Record();
+}
+
+void DecayStorage::DecayInventory(
+    cyclus::toolkit::ResBuf<cyclus::Material>& inventory) {
+  if (!inventory.empty()) {
+    cyclus::Material::Ptr mat = inventory.Pop();
+    mat->Decay(context()->time());
+    inventory.Push(mat);
+  }
+}
+
+void DecayStorage::ExtractHelium(
+    cyclus::toolkit::ResBuf<cyclus::Material>& inventory) {
+  if (!inventory.empty()) {
+    cyclus::Material::Ptr mat = inventory.Pop();
+    cyclus::toolkit::MatQuery mq(mat);
+    
+    cyclus::Material::Ptr helium = mat->ExtractComp(mq.mass(He3_id), He3_comp);
+
+    helium_storage.Push(helium);
+    inventory.Push(mat);
+  }
+}
+
+void DecayStorage::CombineInventory(
+    cyclus::toolkit::ResBuf<cyclus::Material>& inventory) {
+  if (!inventory.empty()) {
+    cyclus::Material::Ptr base = inventory.Pop();
+    int count = inventory.count();
+    for (int i = 0; i < count; i++) {
+      cyclus::Material::Ptr m = inventory.Pop();
+      base->Absorb(m);
+    }
+
+    inventory.Push(base);
+  }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void DecayStorage::Tick() {
+  DecayInventory(tritium_storage);
+  ExtractHelium(tritium_storage);
+  LOG(cyclus::LEV_INFO2, "Storage") << "Quantity to be offered: " << sell_policy.Limit() << " kg.";
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void DecayStorage::Tock() {
+  CombineInventory(input);
+  if (!input.empty()){
+    tritium_storage.Push(input.Pop());
+  }
+  CombineInventory(tritium_storage);
+  RecordInventories(tritium_storage.quantity(), helium_storage.quantity());
+}
+
+// WARNING! Do not change the following this function!!! This enables your
+// archetype to be dynamically loaded and any alterations will cause your
+// archetype to fail.
+extern "C" cyclus::Agent* ConstructDecayStorage(cyclus::Context* ctx) {
+  return new DecayStorage(ctx);
+}
+
+}  // namespace decaystorage

--- a/src/decay_storage.cc
+++ b/src/decay_storage.cc
@@ -4,7 +4,7 @@ namespace decaystorage {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 DecayStorage::DecayStorage(cyclus::Context* ctx) : cyclus::Facility(ctx) {
-  fuel_tracker.Init({&input}, 10000);
+  fuel_tracker.Init({&input}, 100000000);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/decay_storage.cc
+++ b/src/decay_storage.cc
@@ -5,6 +5,10 @@ namespace decaystorage {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 DecayStorage::DecayStorage(cyclus::Context* ctx) : cyclus::Facility(ctx) {
   fuel_tracker.Init({&input}, 100000000);
+
+  input = ResBuf<Material>(true);
+  tritium_storage = ResBuf<Material>(true);
+  helium_storage = ResBuf<Material>(true);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/decay_storage.h
+++ b/src/decay_storage.h
@@ -65,16 +65,6 @@ class DecayStorage : public cyclus::Facility  {
   }
   std::string outcommod;
 
-  #pragma cyclus var { \
-  "tooltip": "(Optional) Maximum tritium inventory (kg)", \
-  "default": 100000000.0, \
-  "doc": "Maximum tritium inventory (kg). If not provided, the default is an arbitrary large number (100,000,000 kg).", \
-  "uilabel": "Maximum Tritium Inventory", \
-  "uitype": "range", \
-  "range": [0.0, CY_LARGE_DOUBLE], \
-  }
-  double max_tritium_inventory;
-
   #pragma cyclus var {"tooltip":"Bulk storage buffer for tritium inventory with decay"}
   cyclus::toolkit::ResBuf<cyclus::Material> tritium_storage;
 
@@ -112,6 +102,8 @@ class DecayStorage : public cyclus::Facility  {
   void RecordInventories(double tritium, double helium);
 
 
+
+  double max_tritium_inventory = 100000000.0;
   const int He3_id = 20030000;
   const cyclus::CompMap He3 = {{He3_id, 1}};
   const cyclus::Composition::Ptr He3_comp = cyclus::Composition::CreateFromAtom(He3);

--- a/src/decay_storage.h
+++ b/src/decay_storage.h
@@ -30,8 +30,7 @@ namespace decaystorage {
 /// Each time step, the facility:
 /// - Tick: Decays all tritium inventory, then extracts accumulated helium-3
 ///         (helium-3 is treated as a byproduct)
-/// - Tock: Transfers incoming material from input buffer to tritium storage
-///         and records current inventories
+/// - Tock: Records current inventories
 /// The tritium_storage buffer uses bulk storage mode for automatic material
 /// combining, and helium-3 is continuously separated and stored independently
 /// as a byproduct (not currently offered to market).
@@ -69,9 +68,6 @@ class DecayStorage : public cyclus::Facility  {
   "uitype": "outcommodity", \
   }
   std::string outcommod;
-
-  #pragma cyclus var {"tooltip":"Bulk input buffer for incoming tritium material"}
-  cyclus::toolkit::ResBuf<cyclus::Material> input;
 
   #pragma cyclus var {"tooltip":"Bulk storage buffer for tritium inventory with decay"}
   cyclus::toolkit::ResBuf<cyclus::Material> tritium_storage;

--- a/src/decay_storage.h
+++ b/src/decay_storage.h
@@ -79,6 +79,7 @@ class DecayStorage : public cyclus::Facility  {
   #pragma cyclus var {"tooltip":"Bulk storage buffer for extracted helium-3 byproduct"}
   cyclus::toolkit::ResBuf<cyclus::Material> helium_storage{true};
 
+  /// Required to make the matl_buy/sell_policy work
   #pragma cyclus var {"tooltip":"Tracker to handle on-hand tritium"}
   cyclus::toolkit::TotalInvTracker fuel_tracker;
 

--- a/src/decay_storage.h
+++ b/src/decay_storage.h
@@ -71,13 +71,13 @@ class DecayStorage : public cyclus::Facility  {
   std::string outcommod;
 
   #pragma cyclus var {"tooltip":"Bulk input buffer for incoming tritium material"}
-  cyclus::toolkit::ResBuf<cyclus::Material> input{true};
+  cyclus::toolkit::ResBuf<cyclus::Material> input;
 
   #pragma cyclus var {"tooltip":"Bulk storage buffer for tritium inventory with decay"}
-  cyclus::toolkit::ResBuf<cyclus::Material> tritium_storage{true};
+  cyclus::toolkit::ResBuf<cyclus::Material> tritium_storage;
 
   #pragma cyclus var {"tooltip":"Bulk storage buffer for extracted helium-3 byproduct"}
-  cyclus::toolkit::ResBuf<cyclus::Material> helium_storage{true};
+  cyclus::toolkit::ResBuf<cyclus::Material> helium_storage;
 
   /// Required to make the matl_buy/sell_policy work
   #pragma cyclus var {"tooltip":"Tracker to handle on-hand tritium"}

--- a/src/decay_storage.h
+++ b/src/decay_storage.h
@@ -7,32 +7,33 @@
 
 namespace decaystorage {
 
-/// @class DecaystorageFacility
+/// @class DecayStorage
 ///
-/// This Facility is intended
-/// as a skeleton to guide the implementation of new Facility
-/// agents.
-/// The DecaystorageFacility class inherits from the Facility class and is
-/// dynamically loaded by the Agent class when requested.
+/// The DecayStorage facility manages tritium storage with radioactive decay
+/// and helium-3 extraction. It accepts tritium material, allows it to decay
+/// over time, and periodically extracts the helium-3 that forms from tritium
+/// decay for separate storage and output.
 ///
 /// @section intro Introduction
-/// Place an introduction to the agent here.
+/// DecayStorage is designed for fuel cycle simulations involving tritium
+/// breeding and handling. It accounts for the radioactive decay of tritium
+/// and enables tracking of both the remaining tritium and accumulated
+/// helium-3 inventories.
 ///
 /// @section agentparams Agent Parameters
-/// Place a description of the required input parameters which define the
-/// agent implementation.
-///
-/// @section optionalparams Optional Parameters
-/// Place a description of the optional input parameters to define the
-/// agent implementation.
+/// - incommod: Input commodity name for accepting tritium material
+/// - outcommod: Output commodity name for offering helium-3
 ///
 /// @section detailed Detailed Behavior
-/// Place a description of the detailed behavior of the agent. Consider
-/// describing the behavior at the tick and tock as well as the behavior
-/// upon sending and receiving materials and messages.
+/// Each time step, the facility:
+/// - Tick: Decays all tritium inventory, then extracts accumulated helium-3
+/// - Tock: Transfers incoming material from input buffer to tritium storage
+///         and records current inventories
+/// The tritium_storage buffer uses bulk storage mode for automatic material
+/// combining, and helium-3 is continuously separated and stored independently.
 class DecayStorage : public cyclus::Facility  {
  public:
-  /// Constructor for DecaystorageFacility Class
+  /// Constructor for DecayStorage Class
   /// @param ctx the cyclus context for access to simulation-wide parameters
   explicit DecayStorage(cyclus::Context* ctx);
 
@@ -44,62 +45,63 @@ class DecayStorage : public cyclus::Facility  {
 
   #pragma cyclus
 
-  #pragma cyclus note {"doc": "A decaystorage facility is provided as a skeleton " \
-                              "for the design of new facility agents."}
+  #pragma cyclus note {"doc": "A DecayStorage facility manages tritium storage " \
+                              "with radioactive decay and helium-3 extraction."}
 
 
 
   #pragma cyclus var { \
-  "tooltip": "Storage input commodity", \
-  "doc": "Input commodity on which Storage requests material.", \
+  "tooltip": "Tritium input commodity", \
+  "doc": "Input commodity on which DecayStorage requests tritium material.", \
   "uilabel": "Input Commodity", \
   "uitype": "incommodity", \
   }
   std::string incommod;
 
   #pragma cyclus var { \
-  "tooltip": "Storage output commodity", \
-  "doc": "Output commodity on which Storage offers material.", \
+  "tooltip": "Helium-3 output commodity", \
+  "doc": "Output commodity on which DecayStorage offers extracted helium-3.", \
   "uilabel": "Output Commodity", \
   "uitype": "outcommodity", \
   }
   std::string outcommod;
 
-  #pragma cyclus var {"tooltip":"Buffer for handling tritium material to be used in reactor"}
+  #pragma cyclus var {"tooltip":"Input buffer for incoming tritium material"}
   cyclus::toolkit::ResBuf<cyclus::Material> input;
 
-  #pragma cyclus var {"tooltip":"Buffer for handling tritium material to be used in reactor"}
+  #pragma cyclus var {"tooltip":"Bulk storage buffer for tritium inventory with decay"}
   cyclus::toolkit::ResBuf<cyclus::Material> tritium_storage{true};
 
-  #pragma cyclus var {"tooltip":"Buffer for handling tritium material to be used in reactor"}
+  #pragma cyclus var {"tooltip":"Storage buffer for extracted helium-3"}
   cyclus::toolkit::ResBuf<cyclus::Material> helium_storage;
 
   #pragma cyclus var {"tooltip":"Tracker to handle on-hand tritium"}
   cyclus::toolkit::TotalInvTracker fuel_tracker;
 
-  /// a policy for requesting material
+  /// Policy for requesting tritium material
   cyclus::toolkit::MatlBuyPolicy buy_policy;
 
-  /// a policy for sending material
+  /// Policy for offering helium-3 material
   cyclus::toolkit::MatlSellPolicy sell_policy;
 
 
 
-  /// Set up policies and buffers:
+  /// Set up policies and buffers
   virtual void EnterNotify();
 
-  /// A verbose printer for the DecaystorageFacility
+  /// A verbose printer for the DecayStorage facility
   virtual std::string str();
 
-  /// The handleTick function specific to the DecaystorageFacility.
-  /// @param time the time of the tick
+  /// Decays tritium inventory and extracts helium-3 each time step
   virtual void Tick();
 
-  /// The handleTick function specific to the DecaystorageFacility.
-  /// @param time the time of the tock
+  /// Transfers incoming material to storage and records inventories
   virtual void Tock();
 
+  /// Extracts helium-3 from decayed tritium and stores it separately
   void ExtractHelium(cyclus::toolkit::ResBuf<cyclus::Material> &inventory);
+  
+  /// Records current tritium and helium-3 inventory quantities
   void RecordInventories(double tritium, double helium);
 
 

--- a/src/decay_storage.h
+++ b/src/decay_storage.h
@@ -1,0 +1,117 @@
+#ifndef CYCLUS_DECAYSTORAGES_DECAYSTORAGE_FACILITY_H_
+#define CYCLUS_DECAYSTORAGES_DECAYSTORAGE_FACILITY_H_
+
+#include <string>
+
+#include "cyclus.h"
+
+namespace decaystorage {
+
+/// @class DecaystorageFacility
+///
+/// This Facility is intended
+/// as a skeleton to guide the implementation of new Facility
+/// agents.
+/// The DecaystorageFacility class inherits from the Facility class and is
+/// dynamically loaded by the Agent class when requested.
+///
+/// @section intro Introduction
+/// Place an introduction to the agent here.
+///
+/// @section agentparams Agent Parameters
+/// Place a description of the required input parameters which define the
+/// agent implementation.
+///
+/// @section optionalparams Optional Parameters
+/// Place a description of the optional input parameters to define the
+/// agent implementation.
+///
+/// @section detailed Detailed Behavior
+/// Place a description of the detailed behavior of the agent. Consider
+/// describing the behavior at the tick and tock as well as the behavior
+/// upon sending and receiving materials and messages.
+class DecayStorage : public cyclus::Facility  {
+ public:
+  /// Constructor for DecaystorageFacility Class
+  /// @param ctx the cyclus context for access to simulation-wide parameters
+  explicit DecayStorage(cyclus::Context* ctx);
+
+  /// The Prime Directive
+  /// Generates code that handles all input file reading and restart operations
+  /// (e.g., reading from the database, instantiating a new object, etc.).
+  /// @warning The Prime Directive must have a space before it! (A fix will be
+  /// in 2.0 ^TM)
+
+  #pragma cyclus
+
+  #pragma cyclus note {"doc": "A decaystorage facility is provided as a skeleton " \
+                              "for the design of new facility agents."}
+
+
+
+  #pragma cyclus var { \
+  "tooltip": "Storage input commodity", \
+  "doc": "Input commodity on which Storage requests material.", \
+  "uilabel": "Input Commodity", \
+  "uitype": "incommodity", \
+  }
+  std::string incommod;
+
+  #pragma cyclus var { \
+  "tooltip": "Storage output commodity", \
+  "doc": "Output commodity on which Storage offers material.", \
+  "uilabel": "Output Commodity", \
+  "uitype": "outcommodity", \
+  }
+  std::string outcommod;
+
+  #pragma cyclus var {"tooltip":"Buffer for handling tritium material to be used in reactor"}
+  cyclus::toolkit::ResBuf<cyclus::Material> input;
+
+  #pragma cyclus var {"tooltip":"Buffer for handling tritium material to be used in reactor"}
+  cyclus::toolkit::ResBuf<cyclus::Material> tritium_storage;
+
+  #pragma cyclus var {"tooltip":"Buffer for handling tritium material to be used in reactor"}
+  cyclus::toolkit::ResBuf<cyclus::Material> helium_storage;
+
+  #pragma cyclus var {"tooltip":"Tracker to handle on-hand tritium"}
+  cyclus::toolkit::TotalInvTracker fuel_tracker;
+
+  /// a policy for requesting material
+  cyclus::toolkit::MatlBuyPolicy buy_policy;
+
+  /// a policy for sending material
+  cyclus::toolkit::MatlSellPolicy sell_policy;
+
+
+
+  /// Set up policies and buffers:
+  virtual void EnterNotify();
+
+  /// A verbose printer for the DecaystorageFacility
+  virtual std::string str();
+
+  /// The handleTick function specific to the DecaystorageFacility.
+  /// @param time the time of the tick
+  virtual void Tick();
+
+  /// The handleTick function specific to the DecaystorageFacility.
+  /// @param time the time of the tock
+  virtual void Tock();
+
+  void DecayInventory(cyclus::toolkit::ResBuf<cyclus::Material> &inventory);
+  void ExtractHelium(cyclus::toolkit::ResBuf<cyclus::Material> &inventory);
+  void CombineInventory(cyclus::toolkit::ResBuf<cyclus::Material> &inventory);
+  void RecordInventories(double tritium, double helium);
+
+
+  const int He3_id = 20030000;
+  const cyclus::CompMap He3 = {{He3_id, 1}};
+  const cyclus::Composition::Ptr He3_comp = cyclus::Composition::CreateFromAtom(He3);
+
+  // And away we go!
+};
+
+}  // namespace decaystorage
+
+#endif  // CYCLUS_DECAYSTORAGES_DECAYSTORAGE_FACILITY_H_

--- a/src/decay_storage.h
+++ b/src/decay_storage.h
@@ -9,28 +9,32 @@ namespace decaystorage {
 
 /// @class DecayStorage
 ///
-/// The DecayStorage facility manages tritium storage with radioactive decay
-/// and helium-3 extraction. It accepts tritium material, allows it to decay
-/// over time, and periodically extracts the helium-3 that forms from tritium
-/// decay for separate storage and output.
+/// The DecayStorage facility provides tritium storage and tracking with
+/// proper radioactive decay accounting. It accepts incoming tritium material,
+/// stores it with bulk storage, applies decay each time step, and offers
+/// the decayed tritium back to the market. Helium-3 extraction from decay is 
+/// performed as a byproduct and may be offered in future enhancements.
 ///
 /// @section intro Introduction
 /// DecayStorage is designed for fuel cycle simulations involving tritium
-/// breeding and handling. It accounts for the radioactive decay of tritium
-/// and enables tracking of both the remaining tritium and accumulated
-/// helium-3 inventories.
+/// breeding and handling. It provides tracking of tritium inventory
+/// with proper decay accounting. The facility accounts for radioactive decay of
+/// tritium each time step and maintains records of both tritium and
+/// accumulated helium-3 inventories.
 ///
 /// @section agentparams Agent Parameters
 /// - incommod: Input commodity name for accepting tritium material
-/// - outcommod: Output commodity name for offering helium-3
+/// - outcommod: Output commodity name for offering stored tritium
 ///
 /// @section detailed Detailed Behavior
 /// Each time step, the facility:
 /// - Tick: Decays all tritium inventory, then extracts accumulated helium-3
+///         (helium-3 is treated as a byproduct)
 /// - Tock: Transfers incoming material from input buffer to tritium storage
 ///         and records current inventories
 /// The tritium_storage buffer uses bulk storage mode for automatic material
-/// combining, and helium-3 is continuously separated and stored independently.
+/// combining, and helium-3 is continuously separated and stored independently
+/// as a byproduct (not currently offered to market).
 class DecayStorage : public cyclus::Facility  {
  public:
   /// Constructor for DecayStorage Class
@@ -45,8 +49,8 @@ class DecayStorage : public cyclus::Facility  {
 
   #pragma cyclus
 
-  #pragma cyclus note {"doc": "A DecayStorage facility manages tritium storage " \
-                              "with radioactive decay and helium-3 extraction."}
+  #pragma cyclus note {"doc": "A DecayStorage facility provides tritium storage " \
+                              "and tracking with proper radioactive decay accounting."}
 
 
 
@@ -59,21 +63,21 @@ class DecayStorage : public cyclus::Facility  {
   std::string incommod;
 
   #pragma cyclus var { \
-  "tooltip": "Helium-3 output commodity", \
-  "doc": "Output commodity on which DecayStorage offers extracted helium-3.", \
+  "tooltip": "Tritium output commodity", \
+  "doc": "Output commodity on which DecayStorage offers decayed tritium material.", \
   "uilabel": "Output Commodity", \
   "uitype": "outcommodity", \
   }
   std::string outcommod;
 
-  #pragma cyclus var {"tooltip":"Input buffer for incoming tritium material"}
-  cyclus::toolkit::ResBuf<cyclus::Material> input;
+  #pragma cyclus var {"tooltip":"Bulk input buffer for incoming tritium material"}
+  cyclus::toolkit::ResBuf<cyclus::Material> input{true};
 
   #pragma cyclus var {"tooltip":"Bulk storage buffer for tritium inventory with decay"}
   cyclus::toolkit::ResBuf<cyclus::Material> tritium_storage{true};
 
-  #pragma cyclus var {"tooltip":"Storage buffer for extracted helium-3"}
-  cyclus::toolkit::ResBuf<cyclus::Material> helium_storage;
+  #pragma cyclus var {"tooltip":"Bulk storage buffer for extracted helium-3 byproduct"}
+  cyclus::toolkit::ResBuf<cyclus::Material> helium_storage{true};
 
   #pragma cyclus var {"tooltip":"Tracker to handle on-hand tritium"}
   cyclus::toolkit::TotalInvTracker fuel_tracker;
@@ -81,7 +85,7 @@ class DecayStorage : public cyclus::Facility  {
   /// Policy for requesting tritium material
   cyclus::toolkit::MatlBuyPolicy buy_policy;
 
-  /// Policy for offering helium-3 material
+  /// Policy for offering tritium material
   cyclus::toolkit::MatlSellPolicy sell_policy;
 
 
@@ -92,13 +96,13 @@ class DecayStorage : public cyclus::Facility  {
   /// A verbose printer for the DecayStorage facility
   virtual std::string str();
 
-  /// Decays tritium inventory and extracts helium-3 each time step
+  /// Decays tritium inventory and extracts helium-3 byproduct each time step
   virtual void Tick();
 
   /// Transfers incoming material to storage and records inventories
   virtual void Tock();
 
-  /// Extracts helium-3 from decayed tritium and stores it separately
+  /// Extracts helium-3 byproduct from decayed tritium and stores it separately
   void ExtractHelium(cyclus::toolkit::ResBuf<cyclus::Material> &inventory);
   
   /// Records current tritium and helium-3 inventory quantities

--- a/src/decay_storage.h
+++ b/src/decay_storage.h
@@ -5,6 +5,8 @@
 
 #include "cyclus.h"
 
+#pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+
 namespace decaystorage {
 
 /// @class DecayStorage
@@ -40,12 +42,6 @@ class DecayStorage : public cyclus::Facility  {
   /// @param ctx the cyclus context for access to simulation-wide parameters
   explicit DecayStorage(cyclus::Context* ctx);
 
-  /// The Prime Directive
-  /// Generates code that handles all input file reading and restart operations
-  /// (e.g., reading from the database, instantiating a new object, etc.).
-  /// @warning The Prime Directive must have a space before it! (A fix will be
-  /// in 2.0 ^TM)
-
   #pragma cyclus
 
   #pragma cyclus note {"doc": "A DecayStorage facility provides tritium storage " \
@@ -68,6 +64,16 @@ class DecayStorage : public cyclus::Facility  {
   "uitype": "outcommodity", \
   }
   std::string outcommod;
+
+  #pragma cyclus var { \
+  "tooltip": "(Optional) Maximum tritium inventory (kg)", \
+  "default": 100000000.0, \
+  "doc": "Maximum tritium inventory (kg). If not provided, the default is an arbitrary large number (100,000,000 kg).", \
+  "uilabel": "Maximum Tritium Inventory", \
+  "uitype": "range", \
+  "range": [0.0, CY_LARGE_DOUBLE], \
+  }
+  double max_tritium_inventory;
 
   #pragma cyclus var {"tooltip":"Bulk storage buffer for tritium inventory with decay"}
   cyclus::toolkit::ResBuf<cyclus::Material> tritium_storage;

--- a/src/decay_storage.h
+++ b/src/decay_storage.h
@@ -69,7 +69,7 @@ class DecayStorage : public cyclus::Facility  {
   cyclus::toolkit::ResBuf<cyclus::Material> input;
 
   #pragma cyclus var {"tooltip":"Buffer for handling tritium material to be used in reactor"}
-  cyclus::toolkit::ResBuf<cyclus::Material> tritium_storage;
+  cyclus::toolkit::ResBuf<cyclus::Material> tritium_storage{true};
 
   #pragma cyclus var {"tooltip":"Buffer for handling tritium material to be used in reactor"}
   cyclus::toolkit::ResBuf<cyclus::Material> helium_storage;
@@ -99,9 +99,7 @@ class DecayStorage : public cyclus::Facility  {
   /// @param time the time of the tock
   virtual void Tock();
 
-  void DecayInventory(cyclus::toolkit::ResBuf<cyclus::Material> &inventory);
   void ExtractHelium(cyclus::toolkit::ResBuf<cyclus::Material> &inventory);
-  void CombineInventory(cyclus::toolkit::ResBuf<cyclus::Material> &inventory);
   void RecordInventories(double tritium, double helium);
 
 

--- a/src/decay_storage_tests.cc
+++ b/src/decay_storage_tests.cc
@@ -1,0 +1,256 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "agent_tests.h"
+#include "context.h"
+#include "decay_storage.h"
+#include "facility_tests.h"
+#include "pyhooks.h"
+
+using cyclus::CompMap;
+using cyclus::Cond;
+using cyclus::Material;
+using cyclus::QueryResult;
+using cyclus::toolkit::MatQuery;
+using decaystorage::DecayStorage;
+
+// Use an anonymous namespace to avoid polluting the global namespace with 
+// test-specific code.
+namespace {
+
+Composition::Ptr tritium() {
+  cyclus::CompMap m;
+  m[10030000] = 1.0;
+  return Composition::CreateFromAtom(m);
+};
+
+Composition::Ptr decayed_tritium() {
+  cyclus::CompMap m;
+  m[10030000] = 0.9;
+  m[20030000] = 0.1;
+  return Composition::CreateFromAtom(m);
+};
+
+std::string common_config =
+    " <incommod>Tritium</incommod>"
+    " <outcommod>Tritium_Out</outcommod>"
+    " <max_tritium_inventory>100000000.0</max_tritium_inventory>";
+
+cyclus::MockSim InitializeSim(std::string config, int simdur) {
+  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:DecayStorage"), config,
+                      simdur);
+
+  sim.AddRecipe("tritium", tritium());
+  sim.AddSource("Tritium").recipe("tritium").Finalize();
+
+  return sim;
+}
+
+QueryResult TimeInventoryQuery(cyclus::MockSim& sim, std::string time) {
+  std::vector<Cond> conds;
+
+  conds.push_back(Cond("Time", "==", time));
+  QueryResult qr = sim.db().Query("StorageInventories", &conds);
+
+  return qr;
+}
+
+}  // namespace
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class DecayStorageTest : public ::testing::Test {
+ protected:
+  cyclus::TestContext tc;
+  DecayStorage* facility;
+
+  virtual void SetUp() {
+    cyclus::PyStart();
+    facility = new DecayStorage(tc.get());
+  }
+
+  virtual void TearDown() {
+    delete facility;
+    cyclus::PyStop();
+  }
+};
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, InitialState) {
+  // Test that the facility is constructed with empty storage buffers
+  EXPECT_EQ(0.0, facility->tritium_storage.quantity());
+  EXPECT_EQ(0.0, facility->helium_storage.quantity());
+  EXPECT_EQ(100000000.0, facility->max_tritium_inventory);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, Print) {
+  EXPECT_NO_THROW(std::string s = facility->str());
+  // Test DecayStorage specific aspects of the print method here
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, Tick) {
+  // Test that Tick can be called without errors on empty storage
+  EXPECT_NO_THROW(facility->Tick());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, Tock) {
+  // Test that Tock can be called without errors
+  EXPECT_NO_THROW(facility->Tock());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, DatabaseRecording) {
+    // Test that inventories are properly recorded to the database
+  
+    std::string config = common_config;
+  
+    int simdur = 2;
+    cyclus::MockSim sim = InitializeSim(config, simdur);
+  
+    int id = sim.Run();
+  
+    QueryResult qr = TimeInventoryQuery(sim, "1");
+    
+    // Verify that records exist in the database
+    EXPECT_GT(qr.rows.size(), 0);
+    
+    // Verify that required fields are present
+    EXPECT_NO_THROW(qr.GetVal<double>("TritiumStorage"));
+    EXPECT_NO_THROW(qr.GetVal<double>("HeliumStorage"));
+    EXPECT_NO_THROW(qr.GetVal<int>("AgentId"));
+    EXPECT_NO_THROW(qr.GetVal<int>("Time"));
+  }
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, BasicMaterialFlow) {
+  // Test basic material flow: receiving tritium, storing it, and recording
+
+  std::string config = common_config;
+
+  int simdur = 2;
+  cyclus::MockSim sim = InitializeSim(config, simdur);
+
+  int id = sim.Run();
+
+  QueryResult qr = TimeInventoryQuery(sim, "1");
+  double tritium_qty = qr.GetVal<double>("TritiumStorage");
+
+  // Should have received and stored some tritium
+  EXPECT_LE(0.0, tritium_qty);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, DecayAndExtractHelium) {
+  // Test that tritium decays over time steps and helium-3 is extracted.
+  // Material is received at time 0, then decays at each tick. Without a sink,
+  // material accumulates and we can observe both the tritium decrease and
+  // helium-3 accumulation from decay.
+
+  std::string config = common_config;
+
+  int simdur = 3;
+  cyclus::MockSim sim = InitializeSim(config, simdur);
+  // No sink added, so material will not be sold and will accumulate
+
+  int id = sim.Run();
+
+  QueryResult qr_1 = TimeInventoryQuery(sim, "1");
+  double tritium_1 = qr_1.GetVal<double>("TritiumStorage");
+  double helium_1 = qr_1.GetVal<double>("HeliumStorage");
+
+  QueryResult qr_2 = TimeInventoryQuery(sim, "2");
+  double tritium_2 = qr_2.GetVal<double>("TritiumStorage");
+  double helium_2 = qr_2.GetVal<double>("HeliumStorage");
+
+  // Verify we have material at time 1
+  EXPECT_LT(0.0, tritium_1);
+
+  // Helium-3 should accumulate as tritium decays
+  EXPECT_LT(helium_1, helium_2);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, EmptyStorageBehavior) {
+  // Test behavior when storage is empty
+
+  std::string config = common_config;
+
+  int simdur = 2;
+  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:DecayStorage"), config,
+                      simdur);
+
+  sim.AddRecipe("tritium", tritium());
+  // No source added, so no material flows
+
+  EXPECT_NO_THROW(int id = sim.Run());
+
+  QueryResult qr = TimeInventoryQuery(sim, "1");
+  double tritium_qty = qr.GetVal<double>("TritiumStorage");
+  double helium_qty = qr.GetVal<double>("HeliumStorage");
+
+  // Both storages should be empty
+  EXPECT_EQ(0.0, tritium_qty);
+  EXPECT_EQ(0.0, helium_qty);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, ExtractHeliumEmptyStorage) {
+  // Test ExtractHelium with empty storage (should not crash)
+
+  EXPECT_NO_THROW(facility->ExtractHelium(facility->tritium_storage));
+  EXPECT_EQ(0.0, facility->helium_storage.quantity());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, EnterNotifyPolicySetup) {
+  // Test that EnterNotify sets up buy and sell policies correctly
+
+  facility->incommod = "Tritium";
+  facility->outcommod = "Tritium_Out";
+
+  EXPECT_NO_THROW(facility->EnterNotify());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(DecayStorageTest, MaterialWithDecay) {
+  // Test with material that already contains some decay products
+
+  std::string config = common_config;
+
+  int simdur = 2;
+  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:DecayStorage"), config,
+                      simdur);
+
+  sim.AddRecipe("tritium", tritium());
+  sim.AddRecipe("decayed_tritium", decayed_tritium());
+  sim.AddSource("Tritium").recipe("decayed_tritium").Finalize();
+
+  int id = sim.Run();
+
+  QueryResult qr = TimeInventoryQuery(sim, "1");
+  double helium_qty = qr.GetVal<double>("HeliumStorage");
+
+  // Should extract helium-3 from the already decayed material
+  EXPECT_LE(0.0, helium_qty);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Do Not Touch! Below section required for connection with Cyclus
+cyclus::Agent* DecayStorageConstructor(cyclus::Context* ctx) {
+  return new DecayStorage(ctx);
+}
+// Required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif  // CYCLUS_AGENT_TESTS_CONNECTED
+INSTANTIATE_TEST_CASE_P(DecayStorage, FacilityTests,
+                        ::testing::Values(&DecayStorageConstructor));
+INSTANTIATE_TEST_CASE_P(DecayStorage, AgentTests,
+                        ::testing::Values(&DecayStorageConstructor));
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+

--- a/src/decay_storage_tests.cc
+++ b/src/decay_storage_tests.cc
@@ -139,7 +139,7 @@ TEST_F(DecayStorageTest, BasicMaterialFlow) {
   double tritium_qty = qr.GetVal<double>("TritiumStorage");
 
   // Should have received and stored some tritium
-  EXPECT_LE(0.0, tritium_qty);
+  EXPECT_LT(0.0, tritium_qty);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
# Summary of Changes

This PR adds the DecayStorage facility to tricycle. I don't remember a ton about its implementation, but I did enough modifications to it that it builds in tricycle and nominally works as intended (I get the little table it's supposed to produce when I give it material). I will leave this mostly up to @trysarahtops to figure out, but I am, of course, happy to help. 

# Related CEPs and Issues

This PR is related to:

Closes #48 

# Associated Developers

None, this one's all me (for better or worse) 😎

# Design Notes

It is worth noting that this code is pretty old, and so it does a few things that I think aren't really necessary or "correct" anymore (namely it has a `CombineInventory()` function from the time before bulk ResBufs). That may be a bit of work to get out, but this should be a pretty good jumping off point. There may also be a few comments which refer to it as `DecaystorageFacility`, which is from when this was (originally) a sub facility that I made with the command (which I think was the old version which made a stub facility, inst, and region). That will need to be cleaned up.

# Testing and Validation

Tricycle builds with this code, and I ran a simulation with it. At a glance, it seemed like the simulation was "working", so I think it's good to go.