### PR TITLE
Added fuel out commodities to FPP archetype

### DIFF
--- a/src/fusion_power_plant.cc
+++ b/src/fusion_power_plant.cc
@@ -83,7 +83,7 @@ void FusionPowerPlant::EnterNotify() {
   }
 
   tritium_sell_policy.Init(this, &tritium_excess, std::string("Excess Tritium"))
-      .Set(fuel_incommod)
+      .Set(fuel_outcommod)
       .Start();
 
   helium_sell_policy.Init(this, &helium_excess, std::string("Helium-3"))

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -124,7 +124,7 @@ class FusionPowerPlant : public cyclus::Facility  {
   std::string fuel_incommod;
 
   #pragma cyclus var { "default":"",\
-    "doc": "Fresh fuel commodity", \
+    "doc": "Fuel commodity leaving power plant", \
     "tooltip": "Name of fuel commodity offered", \
     "uilabel": "Fuel output commodity" \
   }

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -99,7 +99,7 @@ class FusionPowerPlant : public cyclus::Facility  {
   double reserve_inventory;  
 
   #pragma cyclus var { \
-    "doc": "Equilibrium quantity of tritium which is sequestered in the system and no longer accessable", \
+    "doc": "Equilibrium quantity of tritium which is sequestered in the system and no longer accessible", \
     "tooltip": "sequestered tritium equilibrium quantity, should be startup-reserve inventory", \
     "units": "kg", \
     "uilabel": "Equilibrium Quantity of Sequestered Tritium" \
@@ -123,7 +123,14 @@ class FusionPowerPlant : public cyclus::Facility  {
   }
   std::string fuel_incommod;
 
-    #pragma cyclus var { \
+  #pragma cyclus var { "default":"",\
+    "doc": "Fresh fuel commodity", \
+    "tooltip": "Name of fuel commodity offered", \
+    "uilabel": "Fuel output commodity" \
+  }
+  std::string fuel_outcommod;
+
+  #pragma cyclus var { \
     "default": 0.03, \
     "doc": "Fraction of tritium that comes from the (n + Li-7 --> T + He + n) reaction", \
     "tooltip": "Fraction of tritium from Li-7 breeding", \

--- a/src/fusion_power_plant_tests.cc
+++ b/src/fusion_power_plant_tests.cc
@@ -94,13 +94,13 @@ TEST_F(FusionPowerPlantTest, Print) {
   // Test FusionPowerPlant specific aspects of the print method here
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, Tock) {
   EXPECT_NO_THROW(facility->Tock());
   // Test FusionPowerPlant specific behaviors of the Tock function here
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, BlanketCycle) {
   // Test that the agent correctly removes and replaces a portion of the
   // blanket every blanket turnover period. The default period is 1 timestep
@@ -152,7 +152,7 @@ TEST_F(FusionPowerPlantTest, BlanketOverCycle) {
   EXPECT_NO_THROW(sim.Run());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, WrongFuelStartup) {
   // Test that the agent can identify that it has not recieved the correct fuel
   // to startup, and will appropriately not run.
@@ -181,7 +181,7 @@ TEST_F(FusionPowerPlantTest, WrongFuelStartup) {
   EXPECT_EQ(0, seq_trit);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, DecayInventoryExtractHelium) {
   // Test behaviors of the DecayInventory and ExtractHelium function here
   EXPECT_NO_THROW(facility->DecayInventories());
@@ -209,12 +209,13 @@ TEST_F(FusionPowerPlantTest, DecayInventoryExtractHelium) {
   double lambda = 2.57208504984001213e-09;
   double t = 2629846;
 
-  double expected_decay = init_quant - init_quant * std::pow(2, -lambda * t);
+  double expected_decay = (init_quant) -
+                          (init_quant) * std::pow(2, -lambda * t);
 
   EXPECT_NEAR(expected_decay, he3, 1e-6);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, Li7EdgeCases) {
   // Test that FPP does the same thing regardless of Li-7 Contribution
 
@@ -247,7 +248,7 @@ TEST_F(FusionPowerPlantTest, Li7EdgeCases) {
   EXPECT_NEAR(excess_1, excess_2, 1e-3);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, OperateReactorSustainingTBR) {
   // Test behaviors of the OperateReactor function here
 
@@ -267,7 +268,7 @@ TEST_F(FusionPowerPlantTest, OperateReactorSustainingTBR) {
   EXPECT_LT(0, excess_quantity);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, EnterNotifyInitialFillDefault) {
   // Test default fill behavior of EnterNotify. Specifically look that
   // tritium is transacted in the appropriate amounts.
@@ -295,7 +296,7 @@ TEST_F(FusionPowerPlantTest, EnterNotifyInitialFillDefault) {
   EXPECT_EQ(8.121, quantity);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, EnterNotifyScheduleFill) {
   // Test schedule fill behavior of EnterNotify.
 
@@ -338,7 +339,7 @@ TEST_F(FusionPowerPlantTest, EnterNotifyScheduleFill) {
   EXPECT_EQ(0.1, quantity_2);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, EnterNotifyInvalidFill) {
   // Test catch for invalid fill behavior keyword in EnterNotify.
 
@@ -354,14 +355,15 @@ TEST_F(FusionPowerPlantTest, EnterNotifyInvalidFill) {
 
   EXPECT_THROW(int id = sim.Run(), cyclus::KeyError);
 }
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Unfinished
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
   // Test sell policy behavior of enter notify.
 
   std::string config = common_config +
                        " <TBR>1.30</TBR> "
-                       " <fuel_incommod>Tritium</fuel_incommod>";
+                       " <fuel_incommod>Tritium</fuel_incommod>"
+                        "<fuel_outcommod>TritiumFuel</fuel_outcommod>";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config,
@@ -371,7 +373,7 @@ TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
   sim.AddRecipe("enriched_lithium", enriched_lithium());
 
   sim.AddSource("Tritium").capacity(100).recipe("tritium").Finalize();
-  sim.AddSink("Tritium").Finalize();
+  sim.AddSink("TritiumFuel").Finalize();
   sim.AddSource("Enriched_Lithium").recipe("enriched_lithium").Finalize();
 
   int id = sim.Run();
@@ -384,7 +386,7 @@ TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
   EXPECT_EQ(simdur, qr_rows);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Do Not Touch! Below section required for connection with Cyclus
 cyclus::Agent* FusionPowerPlantConstructor(cyclus::Context* ctx) {
   return new FusionPowerPlant(ctx);

--- a/src/fusion_power_plant_tests.cc
+++ b/src/fusion_power_plant_tests.cc
@@ -209,8 +209,8 @@ TEST_F(FusionPowerPlantTest, DecayInventoryExtractHelium) {
   double lambda = 2.57208504984001213e-09;
   double t = 2629846;
 
-  double expected_decay = (init_quant) -
-                          (init_quant) * std::pow(2, -lambda * t);
+  double expected_decay = init_quant -
+                          init_quant * std::pow(2, -lambda * t);
 
   EXPECT_NEAR(expected_decay, he3, 1e-6);
 }
@@ -355,7 +355,6 @@ TEST_F(FusionPowerPlantTest, EnterNotifyInvalidFill) {
 
   EXPECT_THROW(int id = sim.Run(), cyclus::KeyError);
 }
-// Unfinished
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
   // Test sell policy behavior of enter notify.
@@ -363,7 +362,7 @@ TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
   std::string config = common_config +
                        " <TBR>1.30</TBR> "
                        " <fuel_incommod>Tritium</fuel_incommod>"
-                        "<fuel_outcommod>TritiumFuel</fuel_outcommod>";
+                        "<fuel_outcommod>TritiumFromFPP</fuel_outcommod>";
 
   int simdur = 10;
   cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config,
@@ -373,7 +372,7 @@ TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
   sim.AddRecipe("enriched_lithium", enriched_lithium());
 
   sim.AddSource("Tritium").capacity(100).recipe("tritium").Finalize();
-  sim.AddSink("TritiumFuel").Finalize();
+  sim.AddSink("TritiumFromFPP").Finalize();
   sim.AddSource("Enriched_Lithium").recipe("enriched_lithium").Finalize();
 
   int id = sim.Run();


### PR DESCRIPTION
### Summary of Changes
This PR adds fuel outcommodity as an input for the Fusion Power Plant archetype in tricycle. It allows the output commodity to be set differently than the input commodity.