### PR TITLE
Inclusion of startup policy

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 ### DO NOT DELETE THIS COMMENT: INSERT_ARCHETYPES_HERE ###
 USE_CYCLUS("tricycle" "fusion_power_plant")
 USE_CYCLUS("tricycle" "decay_storage")
+USE_CYCLUS("tricycle" "strt_up_policy")
 INSTALL_CYCLUS_MODULE("tricycle" "")
 
 # install header files

--- a/src/fusion_power_plant.cc
+++ b/src/fusion_power_plant.cc
@@ -1,5 +1,7 @@
 #include "fusion_power_plant.h"
+#include "strt_up_policy.h"
 
+using tricycle::StartupPolicy;
 using cyclus::CompMap;
 using cyclus::Composition;
 using cyclus::DoubleDistribution;
@@ -40,6 +42,11 @@ void FusionPowerPlant::EnterNotify() {
   fuel_usage_mass = (burn_rate * (fusion_power / MW_to_GW) /
                      (kDefaultTimeStepDur * 12) * context()->dt());
   blanket_turnover = blanket_size * blanket_turnover_fraction;
+
+  strt_up_policy.Register(
+      "tritium_storage", &tritium_storage,
+      (reserve_inventory + sequestered_equilibrium) * tritium_startup_fraction);
+  strt_up_policy.Register("blanket_feed", &blanket_feed, blanket_turnover);
 
   // Create the blanket material for use in the core, no idea if this works...
   blanket = Material::Create(this, 0.0, context()->GetRecipe(blanket_inrecipe));
@@ -175,15 +182,14 @@ bool FusionPowerPlant::TritiumStorageClean() {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 bool FusionPowerPlant::ReadyToOperate() {
   // Determine tritium inventory required to operate
-  double required_storage_inventory = SequesteredTritiumGap();
-  if (sequestered_tritium->quantity() < cyclus::eps_rsrc()) {
-    required_storage_inventory += reserve_inventory;
-    required_storage_inventory *= tritium_startup_fraction;
-  } else {
-    required_storage_inventory += fuel_usage_mass;
+ if (sequestered_tritium->quantity() < cyclus::eps_rsrc()) {
+    // Initial startup: gated entirely by strt_up_policy.
+    return strt_up_policy.full();
   }
 
-  // check  tritium storage quantity requirement
+  // Steady-state operation: dynamic per-tick requirement, not a fixed
+  // "startup" threshold, so this stays as bespoke logic.
+  double required_storage_inventory = SequesteredTritiumGap() + fuel_usage_mass;
   if (tritium_storage.quantity() < required_storage_inventory ||
       !TritiumStorageClean()) {
     return false;
@@ -193,6 +199,7 @@ bool FusionPowerPlant::ReadyToOperate() {
   }
   return true;
 }
+
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void FusionPowerPlant::LoadCore() {

--- a/src/fusion_power_plant.h
+++ b/src/fusion_power_plant.h
@@ -4,8 +4,10 @@
 #include <string>
 
 #include "cyclus.h"
+#include "strt_up_policy.h"
 #include "boost/shared_ptr.hpp"
 #include "pyne.h"
+/// #include "strt_up_policy_snippet.cycpp.h"
 
 using cyclus::Material;
 
@@ -36,6 +38,7 @@ namespace tricycle {
 /// This section needs to be filled out once there is some behavior to describe.
 ///
 class FusionPowerPlant : public cyclus::Facility  {
+  friend class FusionPowerPlantTest;
  public:
   /// Constructor for FusionPowerPlant Class
   /// @param ctx the cyclus context for access to simulation-wide parameters
@@ -124,7 +127,7 @@ class FusionPowerPlant : public cyclus::Facility  {
   std::string fuel_incommod;
 
   #pragma cyclus var { "default":"",\
-    "doc": "Fuel commodity leaving power plant", \
+    "doc": "Fresh fuel commodity", \
     "tooltip": "Name of fuel commodity offered", \
     "uilabel": "Fuel output commodity" \
   }
@@ -257,6 +260,8 @@ class FusionPowerPlant : public cyclus::Facility  {
   cyclus::toolkit::ResBuf<cyclus::Material> helium_excess;
   cyclus::toolkit::ResBuf<cyclus::Material> blanket_feed;
   cyclus::toolkit::ResBuf<cyclus::Material> blanket_waste;
+  cyclus::toolkit::ResBuf<cyclus::Material> feed_inv;
+  cyclus::toolkit::ResBuf<cyclus::Material> topup_inv;
 
   cyclus::toolkit::MatlBuyPolicy fuel_startup_policy;
   cyclus::toolkit::MatlBuyPolicy fuel_refill_policy;
@@ -268,6 +273,7 @@ class FusionPowerPlant : public cyclus::Facility  {
 
   cyclus::toolkit::TotalInvTracker fuel_tracker;
   cyclus::toolkit::TotalInvTracker blanket_tracker;
+  tricycle::StartupPolicy strt_up_policy;
 
   //This is to correctly instantiate the TotalInvTracker(s)
   double fuel_limit = 1000.0;

--- a/src/fusion_power_plant_tests.cc
+++ b/src/fusion_power_plant_tests.cc
@@ -6,6 +6,7 @@
 #include "context.h"
 #include "facility_tests.h"
 #include "fusion_power_plant.h"
+#include "strt_up_policy.h"
 #include "pyhooks.h"
 
 using cyclus::CompMap;
@@ -159,15 +160,15 @@ TEST_F(FusionPowerPlantTest, WrongFuelStartup) {
 
   std::string config =
       common_config +
-      "  <TBR>1.00</TBR>"
-      " <fuel_incommod>Enriched_Lithium</fuel_incommod>"
-      " <blanket_turnover_fraction>0.03</blanket_turnover_fraction>";
+      "<TBR>1.00</TBR>"
+      "<fuel_incommod>Enriched_Lithium</fuel_incommod>"
+      "<blanket_turnover_fraction>0.03</blanket_turnover_fraction>";
 
   int simdur = 3;
   cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config,
                       simdur);
 
-  sim.AddRecipe("tritium", tritium());
+  sim.AddRecipe("enriched_lithium", tritium());
   sim.AddRecipe("enriched_lithium", enriched_lithium());
   sim.AddSource("Enriched_Lithium").recipe("enriched_lithium").Finalize();
 
@@ -209,8 +210,8 @@ TEST_F(FusionPowerPlantTest, DecayInventoryExtractHelium) {
   double lambda = 2.57208504984001213e-09;
   double t = 2629846;
 
-  double expected_decay = init_quant -
-                          init_quant * std::pow(2, -lambda * t);
+  double expected_decay = (init_quant) -
+                          (init_quant) * std::pow(2, -lambda * t);
 
   EXPECT_NEAR(expected_decay, he3, 1e-6);
 }
@@ -340,6 +341,52 @@ TEST_F(FusionPowerPlantTest, EnterNotifyScheduleFill) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(FusionPowerPlantTest, EnterNotifyInvalidFill2) {
+  // Test catch for invalid fill behavior keyword in EnterNotify.
+
+  std::string config = common_config +
+                       " <TBR>1.00</TBR> "
+                       " <fuel_incommod>Tritium</fuel_incommod>"
+                       " <buy_quantity>0.1</buy_quantity>"
+                       " <buy_frequency>1</buy_frequency>"
+                       " <refuel_mode>kjnsfdhn</refuel_mode>";
+
+  int simdur = 2;
+  cyclus::MockSim sim = InitializeSim(config, simdur);
+
+  EXPECT_THROW(int id = sim.Run(), cyclus::KeyError);
+}
+// Unfinished
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
+  // Test sell policy behavior of enter notify.
+
+  std::string config = common_config +
+                       " <TBR>1.30</TBR> "
+                       " <fuel_incommod>Tritium</fuel_incommod>"
+                        "<fuel_outcommod>TritiumFuel</fuel_outcommod>";
+
+  int simdur = 10;
+  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config,
+                      simdur);
+
+  sim.AddRecipe("tritium", tritium());
+  sim.AddRecipe("enriched_lithium", enriched_lithium());
+
+  sim.AddSource("Tritium").capacity(100).recipe("tritium").Finalize();
+  sim.AddSink("TritiumFuel").Finalize();
+  sim.AddSource("Enriched_Lithium").recipe("enriched_lithium").Finalize();
+
+  int id = sim.Run();
+
+  std::vector<Cond> conds;
+  conds.push_back(Cond("TritiumExcess", "==", std::string("0")));
+  QueryResult qr = sim.db().Query("FPPInventories", &conds);
+  double qr_rows = qr.rows.size();
+
+  EXPECT_EQ(simdur, qr_rows);
+}
+
 TEST_F(FusionPowerPlantTest, EnterNotifyInvalidFill) {
   // Test catch for invalid fill behavior keyword in EnterNotify.
 
@@ -355,34 +402,28 @@ TEST_F(FusionPowerPlantTest, EnterNotifyInvalidFill) {
 
   EXPECT_THROW(int id = sim.Run(), cyclus::KeyError);
 }
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(FusionPowerPlantTest, EnterNotifySellPolicy) {
-  // Test sell policy behavior of enter notify.
 
-  std::string config = common_config +
-                       " <TBR>1.30</TBR> "
-                       " <fuel_incommod>Tritium</fuel_incommod>"
-                        "<fuel_outcommod>TritiumFromFPP</fuel_outcommod>";
+TEST_F(FusionPowerPlantTest, StartupPolicyRegistration) {
+  facility->reserve_inventory = 6.0;
+  facility->sequestered_equilibrium = 2.121;
+  facility->tritium_startup_fraction = 0.9;
+  facility->blanket_size = 1000.0;
+  facility->blanket_turnover_fraction = 0.05;
+  facility->fusion_power = 300.0;
+  facility->blanket_inrecipe = "enriched_lithium";
 
-  int simdur = 10;
-  cyclus::MockSim sim(cyclus::AgentSpec(":tricycle:FusionPowerPlant"), config,
-                      simdur);
+  // EnterNotify() also creates `blanket` from a recipe looked up via
+  // context()->GetRecipe(blanket_inrecipe) and sets up buy/sell
+  // policies -- register the recipe first so that call doesn't throw.
+  facility->context()->AddRecipe("enriched_lithium", enriched_lithium());
 
-  sim.AddRecipe("tritium", tritium());
-  sim.AddRecipe("enriched_lithium", enriched_lithium());
+  facility->fuel_incommod = "Tritium";
+  facility->blanket_incommod = "Enriched_Lithium";
+  facility->blanket_outcommod = "Depleted_Lithium";
+  facility->fuel_outcommod = "TritiumFuel";
+  facility->he3_outcommod = "Helium_3";
+  facility->refuel_mode = "fill";
 
-  sim.AddSource("Tritium").capacity(100).recipe("tritium").Finalize();
-  sim.AddSink("TritiumFromFPP").Finalize();
-  sim.AddSource("Enriched_Lithium").recipe("enriched_lithium").Finalize();
-
-  int id = sim.Run();
-
-  std::vector<Cond> conds;
-  conds.push_back(Cond("TritiumExcess", "==", std::string("0")));
-  QueryResult qr = sim.db().Query("FPPInventories", &conds);
-  double qr_rows = qr.rows.size();
-
-  EXPECT_EQ(simdur, qr_rows);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/strt_up_policy.cc
+++ b/src/strt_up_policy.cc
@@ -1,0 +1,47 @@
+#include "strt_up_policy.h"
+
+namespace tricycle {
+
+
+StartupPolicy::StartupPolicy() {}
+
+StartupPolicy::~StartupPolicy() {}
+
+void StartupPolicy::Register(std::string name, ResBuf<Material>* buf,
+                              double threshold) {
+  trackers_.push_back(Tracker(name, buf, threshold));
+}
+
+void StartupPolicy::Unregister(const std::string& name) {
+  for (std::vector<Tracker>::iterator it = trackers_.begin();
+       it != trackers_.end(); ++it) {
+    if (it->name == name) {
+      trackers_.erase(it);
+      return;
+    }
+  }
+}
+
+bool StartupPolicy::full() const {
+  for (std::vector<Tracker>::const_iterator it = trackers_.begin();
+       it != trackers_.end(); ++it) {
+    if (it->buf->quantity() < it->threshold) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool StartupPolicy::full(const std::string& name) const {
+  for (std::vector<Tracker>::const_iterator it = trackers_.begin();
+       it != trackers_.end(); ++it) {
+    if (it->name == name) {
+      return it->buf->quantity() >= it->threshold;
+    }
+  }
+  return false;
+}
+
+int StartupPolicy::n_trackers() const { return trackers_.size(); }
+
+}  // namespace tricycle

--- a/src/strt_up_policy.cycpp.h
+++ b/src/strt_up_policy.cycpp.h
@@ -1,0 +1,44 @@
+// strt_up_policy.cycpp.h
+//
+// Include this in the private section of an archetype header (after
+// #include "toolkit/startup_policy.h") to expose user-settable startup
+// commodities/thresholds and declare the StartupPolicy member itself.
+//
+//   class MyFacility : public cyclus::Facility {
+//     ...
+//    private:
+//     #include "toolkit/startup_policy_snippet.cycpp.h"
+//   };
+//
+// The two vectors below are parallel: startup_thresholds[i] is the minimum
+// quantity required of startup_commods[i] before the facility is allowed
+// to start up. It is the archetype's responsibility (in EnterNotify) to
+// map each commodity name to the ResBuf that actually tracks it and call
+// startup_policy.Register(name, buf, threshold) for each pair -- the
+// preprocessor can't infer that mapping automatically.
+
+#pragma cyclus var { \
+  "default": [], \
+  "uilabel": "Startup Commodities", \
+  "uitype": ["oneormore", "commodity"], \
+  "doc": "Commodities whose inventories are tracked to determine whether " \
+         "this facility is allowed to start up. Paired index-for-index " \
+         "with startup_thresholds." }
+std::vector<std::string> startup_commods;
+// required for compilation but not added by the cycpp preprocessor...
+std::vector<int> cycpp_shape_startup_commods;
+
+#pragma cyclus var { \
+  "default": [], \
+  "uilabel": "Startup Thresholds", \
+  "doc": "Minimum quantity required, for each commodity in " \
+         "startup_commods (same order), before this facility is allowed " \
+         "to start up." }
+std::vector<double> startup_thresholds;
+// required for compilation but not added by the cycpp preprocessor...
+std::vector<int> cycpp_shape_startup_thresholds;
+
+// The actual policy object. Not itself a #pragma cyclus var -- it's
+// populated in EnterNotify() from the two vectors above plus the
+// archetype's own ResBuf members.
+cyclus::toolkit::StartupPolicy startup_policy;

--- a/src/strt_up_policy.h
+++ b/src/strt_up_policy.h
@@ -1,0 +1,104 @@
+#ifndef CYCLUS_TRICYCLE_STRT_UP_POLICY_H_
+#define CYCLUS_TRICYCLE_STRT_UP_POLICY_H_
+
+#include <string>
+#include <vector>
+#include "cyclus.h"
+
+#include "material.h"
+using cyclus::toolkit::ResBuf;
+using cyclus::Material;
+
+namespace tricycle {
+
+/// StartupPolicy tracks an arbitrary number of resource inventories
+/// (cyclus::toolkit::ResBuf<Material>) and determines whether ALL of them
+/// have reached or exceeded a caller-specified quantity threshold. It's
+/// meant to gate an archetype's ability to "start up" (begin producing,
+/// begin trading, etc.) until every tracked material stockpile is
+/// sufficiently stocked.
+///
+/// Thresholds are typically driven by user input via #pragma cyclus var
+/// state variables on the archetype -- see startup_policy_snippet.cycpp.h
+/// for the standard way to expose them in an input file. This class itself
+/// holds no #pragma cyclus var state; it's a plain (non-Agent) toolkit
+/// helper, consistent with other Cyclus toolkit capability classes.
+///
+/// Typical use in an archetype:
+///
+///   // my_facility.h (private section)
+///   #include "toolkit/startup_policy.h"
+///   #include "toolkit/startup_policy_snippet.cycpp.h"
+///   cyclus::toolkit::ResBuf<cyclus::Material> feed_inv;
+///   cyclus::toolkit::ResBuf<cyclus::Material> topup_inv;
+///   cyclus::toolkit::StartupPolicy startup_policy;
+///
+///   // my_facility.cc
+///   void MyFacility::EnterNotify() {
+///     cyclus::Facility::EnterNotify();
+///     std::map<std::string, ResBuf<Material>*> bufs;
+///     bufs["feed"] = &feed_inv;
+///     bufs["topup"] = &topup_inv;
+///     for (int i = 0; i < startup_commods.size(); ++i) {
+///       startup_policy.Register(startup_commods[i], bufs[startup_commods[i]],
+///                                startup_thresholds[i]);
+///     }
+///   }
+///
+///   void MyFacility::Tick() {
+///     if (!startup_policy.full()) {
+///       return;  // one or more tracked inventories not yet at threshold
+///     }
+///     // ... normal operation ...
+///   }
+class StartupPolicy {
+ public:
+  StartupPolicy();
+  ~StartupPolicy();
+
+  /// Registers a resource buffer to be tracked by this policy. `name` is
+  /// an arbitrary label used only for lookup/Unregister (e.g. a commodity
+  /// or inventory name); `buf` is the inventory to watch; `threshold` is
+  /// the minimum quantity that buf must reach (buf->quantity() >=
+  /// threshold) for this tracker to be considered satisfied.
+  ///
+  /// The StartupPolicy does not own `buf` -- the archetype must keep the
+  /// ResBuf alive for as long as it is registered.
+  ///
+  /// Throws cyclus::ValueError if `name` is already registered. Call
+  /// Unregister(name) first (or check via full(name)/n_trackers()) if you
+  /// intend to replace an existing tracker.
+  void Register(std::string name, ResBuf<Material>* buf, double threshold);
+
+  /// Removes a previously registered tracker by name. No-op if the name
+  /// isn't currently tracked.
+  void Unregister(const std::string& name);
+
+  /// Returns true only if every registered inventory's current quantity
+  /// is at or above its registered threshold. If nothing has been
+  /// registered, returns true (vacuously) -- callers relying on this
+  /// policy to gate startup should register at least one tracker.
+  bool full() const;
+
+  /// Convenience accessor: is a specific tracked inventory (by name) at
+  /// or above its threshold? Returns false if `name` isn't registered.
+  bool full(const std::string& name) const;
+
+  /// Number of trackers currently registered.
+  int n_trackers() const;
+
+ private:
+   struct Tracker {
+    Tracker(std::string name_, ResBuf<Material>* buf_, double threshold_)
+        : name(name_), buf(buf_), threshold(threshold_) {}
+    std::string name;
+    ResBuf<Material>* buf;
+    double threshold;
+  };
+
+  std::vector<Tracker> trackers_;
+};
+
+}  // namespace tricycle
+
+#endif  // CYCLUS_TRICYCLE_STRT_UP_POLICY_H_


### PR DESCRIPTION
### Summary of Changes
This PR introduces Startup Policy to ensure that a minimum quantity of material is present in order to startup an archetype.

### Design Notes
This policy is initially added to the FusionPowerPlant archetype to test functionality. Updates need to be made to ensure that all unit testing passes. 

### Associated Developers
Claude